### PR TITLE
Support Windows via MSYS2

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ This GitHub Action offers you a direct way to interact with the host system on w
 
 ## Supported Operating Systems
 
-- `Linux`
-- `macOS`
-- (`Window` is **not** supported. It will be skipped so that the Pipeline does not fail)
+- Linux
+- macOS
+- Windows
 
 ## Getting Started
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,6 +16,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 const os = __importStar(__webpack_require__(87));
+const utils_1 = __webpack_require__(278);
 /**
  * Commands
  *
@@ -69,28 +70,14 @@ class Command {
         return cmdStr;
     }
 }
-/**
- * Sanitizes an input into a string so it can be passed into issueCommand safely
- * @param input input to sanitize into a string
- */
-function toCommandValue(input) {
-    if (input === null || input === undefined) {
-        return '';
-    }
-    else if (typeof input === 'string' || input instanceof String) {
-        return input;
-    }
-    return JSON.stringify(input);
-}
-exports.toCommandValue = toCommandValue;
 function escapeData(s) {
-    return toCommandValue(s)
+    return utils_1.toCommandValue(s)
         .replace(/%/g, '%25')
         .replace(/\r/g, '%0D')
         .replace(/\n/g, '%0A');
 }
 function escapeProperty(s) {
-    return toCommandValue(s)
+    return utils_1.toCommandValue(s)
         .replace(/%/g, '%25')
         .replace(/\r/g, '%0D')
         .replace(/\n/g, '%0A')
@@ -123,6 +110,8 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 const command_1 = __webpack_require__(351);
+const file_command_1 = __webpack_require__(717);
+const utils_1 = __webpack_require__(278);
 const os = __importStar(__webpack_require__(87));
 const path = __importStar(__webpack_require__(622));
 /**
@@ -149,9 +138,17 @@ var ExitCode;
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function exportVariable(name, val) {
-    const convertedVal = command_1.toCommandValue(val);
+    const convertedVal = utils_1.toCommandValue(val);
     process.env[name] = convertedVal;
-    command_1.issueCommand('set-env', { name }, convertedVal);
+    const filePath = process.env['GITHUB_ENV'] || '';
+    if (filePath) {
+        const delimiter = '_GitHubActionsFileCommandDelimeter_';
+        const commandValue = `${name}<<${delimiter}${os.EOL}${convertedVal}${os.EOL}${delimiter}`;
+        file_command_1.issueCommand('ENV', commandValue);
+    }
+    else {
+        command_1.issueCommand('set-env', { name }, convertedVal);
+    }
 }
 exports.exportVariable = exportVariable;
 /**
@@ -167,7 +164,13 @@ exports.setSecret = setSecret;
  * @param inputPath
  */
 function addPath(inputPath) {
-    command_1.issueCommand('add-path', {}, inputPath);
+    const filePath = process.env['GITHUB_PATH'] || '';
+    if (filePath) {
+        file_command_1.issueCommand('PATH', inputPath);
+    }
+    else {
+        command_1.issueCommand('add-path', {}, inputPath);
+    }
     process.env['PATH'] = `${inputPath}${path.delimiter}${process.env['PATH']}`;
 }
 exports.addPath = addPath;
@@ -329,6 +332,66 @@ exports.getState = getState;
 
 /***/ }),
 
+/***/ 717:
+/***/ (function(__unused_webpack_module, exports, __webpack_require__) {
+
+
+// For internal use, subject to change.
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
+    result["default"] = mod;
+    return result;
+};
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+// We use any as a valid input type
+/* eslint-disable @typescript-eslint/no-explicit-any */
+const fs = __importStar(__webpack_require__(747));
+const os = __importStar(__webpack_require__(87));
+const utils_1 = __webpack_require__(278);
+function issueCommand(command, message) {
+    const filePath = process.env[`GITHUB_${command}`];
+    if (!filePath) {
+        throw new Error(`Unable to find environment variable for file command ${command}`);
+    }
+    if (!fs.existsSync(filePath)) {
+        throw new Error(`Missing file at path: ${filePath}`);
+    }
+    fs.appendFileSync(filePath, `${utils_1.toCommandValue(message)}${os.EOL}`, {
+        encoding: 'utf8'
+    });
+}
+exports.issueCommand = issueCommand;
+//# sourceMappingURL=file-command.js.map
+
+/***/ }),
+
+/***/ 278:
+/***/ ((__unused_webpack_module, exports) => {
+
+
+// We use any as a valid input type
+/* eslint-disable @typescript-eslint/no-explicit-any */
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+/**
+ * Sanitizes an input into a string so it can be passed into issueCommand safely
+ * @param input input to sanitize into a string
+ */
+function toCommandValue(input) {
+    if (input === null || input === undefined) {
+        return '';
+    }
+    else if (typeof input === 'string' || input instanceof String) {
+        return input;
+    }
+    return JSON.stringify(input);
+}
+exports.toCommandValue = toCommandValue;
+//# sourceMappingURL=utils.js.map
+
+/***/ }),
+
 /***/ 1:
 /***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
 
@@ -358,7 +421,14 @@ var external_child_process_ = __webpack_require__(129);
 
 const execShellCommand = (cmd) => {
   return new Promise((resolve, reject) => {
-    const process = (0,external_child_process_.spawn)(cmd, [], { shell: true })
+    const process = global.process.platform !== "win32" ?
+      (0,external_child_process_.spawn)(cmd, [], { shell: true }) :
+      (0,external_child_process_.spawn)("C:\\msys64\\usr\\bin\\bash.exe", [ "-lc", cmd ], {
+        env: {
+          "CHERE_INVOKING": "1", /* do not `cd` to home */
+          "MSYSTEM": "MINGW64", /* include the MINGW programs in C:/msys64/mingw64/bin/ */
+        }
+      })
     let stdout = ""
     process.stdout.on('data', (data) => {
       console.log(data.toString());
@@ -391,26 +461,25 @@ const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms));
 async function run() {
   const optionalSudoPrefix = core.getInput('sudo') === "true" ? "sudo " : "";
   try {
-    if (process.platform === "win32") {
-      core.info("Windows is not supported by tmate, skipping...")
-      return
-    }
-
     core.debug("Installing dependencies")
     if (process.platform === "darwin") {
       await execShellCommand('brew install tmate');
+    } else if (process.platform === "win32") {
+      await execShellCommand('pacman -Sy --noconfirm tmate');
     } else {
       await execShellCommand(optionalSudoPrefix + 'apt-get update');
       await execShellCommand(optionalSudoPrefix + 'apt-get install -y tmate openssh-client');
     }
     core.debug("Installed dependencies successfully");
 
-    core.debug("Generating SSH keys")
-    external_fs_default().mkdirSync(external_path_default().join(external_os_default().homedir(), ".ssh"), { recursive: true })
-    try {
-      await execShellCommand(`echo -e 'y\n'|ssh-keygen -q -t rsa -N "" -f ~/.ssh/id_rsa`);
-    } catch { }
-    core.debug("Generated SSH-Key successfully")
+    if (process.platform !== "win32") {
+      core.debug("Generating SSH keys")
+      external_fs_default().mkdirSync(external_path_default().join(external_os_default().homedir(), ".ssh"), { recursive: true })
+      try {
+        await execShellCommand(`echo -e 'y\n'|ssh-keygen -q -t rsa -N "" -f ~/.ssh/id_rsa`);
+      } catch { }
+      core.debug("Generated SSH-Key successfully")
+    }
 
     core.debug("Creating new session")
     await execShellCommand('tmate -S /tmp/tmate.sock new-session -d');
@@ -422,11 +491,12 @@ async function run() {
     const tmateWeb = await execShellCommand(`tmate -S /tmp/tmate.sock display -p '#{tmate_web}'`);
 
     console.debug("Entering main loop")
+    const continuePath = process.platform !== "win32" ? "/continue" : "C:/msys64/continue"
     while (true) {
       core.info(`WebURL: ${tmateWeb}`);
       core.info(`SSH: ${tmateSSH}`);
 
-      const skip = external_fs_default().existsSync("/continue") || external_fs_default().existsSync(external_path_default().join(process.env.GITHUB_WORKSPACE, "continue"))
+      const skip = external_fs_default().existsSync(continuePath) || external_fs_default().existsSync(external_path_default().join(process.env.GITHUB_WORKSPACE, "continue"))
       if (skip) {
         core.info("Existing debugging session because '/continue' file was created")
         break

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -2,7 +2,14 @@ import { spawn } from 'child_process'
 
 export const execShellCommand = (cmd) => {
   return new Promise((resolve, reject) => {
-    const process = spawn(cmd, [], { shell: true })
+    const process = global.process.platform !== "win32" ?
+      spawn(cmd, [], { shell: true }) :
+      spawn("C:\\msys64\\usr\\bin\\bash.exe", [ "-lc", cmd ], {
+        env: {
+          "CHERE_INVOKING": "1", /* do not `cd` to home */
+          "MSYSTEM": "MINGW64", /* include the MINGW programs in C:/msys64/mingw64/bin/ */
+        }
+      })
     let stdout = ""
     process.stdout.on('data', (data) => {
       console.log(data.toString());

--- a/src/index.js
+++ b/src/index.js
@@ -10,26 +10,25 @@ const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms));
 export async function run() {
   const optionalSudoPrefix = core.getInput('sudo') === "true" ? "sudo " : "";
   try {
-    if (process.platform === "win32") {
-      core.info("Windows is not supported by tmate, skipping...")
-      return
-    }
-
     core.debug("Installing dependencies")
     if (process.platform === "darwin") {
       await execShellCommand('brew install tmate');
+    } else if (process.platform === "win32") {
+      await execShellCommand('pacman -Sy --noconfirm tmate');
     } else {
       await execShellCommand(optionalSudoPrefix + 'apt-get update');
       await execShellCommand(optionalSudoPrefix + 'apt-get install -y tmate openssh-client');
     }
     core.debug("Installed dependencies successfully");
 
-    core.debug("Generating SSH keys")
-    fs.mkdirSync(path.join(os.homedir(), ".ssh"), { recursive: true })
-    try {
-      await execShellCommand(`echo -e 'y\n'|ssh-keygen -q -t rsa -N "" -f ~/.ssh/id_rsa`);
-    } catch { }
-    core.debug("Generated SSH-Key successfully")
+    if (process.platform !== "win32") {
+      core.debug("Generating SSH keys")
+      fs.mkdirSync(path.join(os.homedir(), ".ssh"), { recursive: true })
+      try {
+        await execShellCommand(`echo -e 'y\n'|ssh-keygen -q -t rsa -N "" -f ~/.ssh/id_rsa`);
+      } catch { }
+      core.debug("Generated SSH-Key successfully")
+    }
 
     core.debug("Creating new session")
     await execShellCommand('tmate -S /tmp/tmate.sock new-session -d');
@@ -41,11 +40,12 @@ export async function run() {
     const tmateWeb = await execShellCommand(`tmate -S /tmp/tmate.sock display -p '#{tmate_web}'`);
 
     console.debug("Entering main loop")
+    const continuePath = process.platform !== "win32" ? "/continue" : "C:/msys64/continue"
     while (true) {
       core.info(`WebURL: ${tmateWeb}`);
       core.info(`SSH: ${tmateSSH}`);
 
-      const skip = fs.existsSync("/continue") || fs.existsSync(path.join(process.env.GITHUB_WORKSPACE, "continue"))
+      const skip = fs.existsSync(continuePath) || fs.existsSync(path.join(process.env.GITHUB_WORKSPACE, "continue"))
       if (skip) {
         core.info("Existing debugging session because '/continue' file was created")
         break

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -18,12 +18,18 @@ describe('Tmate GitHub integration', () => {
     })
   });
 
-  it('should skip for windows', async () => {
+  it('should handle the main loop for Windows', async () => {
     Object.defineProperty(process, "platform", {
       value: "win32"
     })
+    core.getInput.mockReturnValue("true")
+    const customConnectionString = "foobar"
+    execShellCommand.mockReturnValue(Promise.resolve(customConnectionString))
     await run()
-    expect(core.info).toHaveBeenCalledWith('Windows is not supported by tmate, skipping...');
+    expect(execShellCommand).toHaveBeenNthCalledWith(1, "pacman -Sy --noconfirm tmate")
+    expect(core.info).toHaveBeenNthCalledWith(1, `WebURL: ${customConnectionString}`);
+    expect(core.info).toHaveBeenNthCalledWith(2, `SSH: ${customConnectionString}`);
+    expect(core.info).toHaveBeenNthCalledWith(3, "Existing debugging session because '/continue' file was created");
   });
   it('should be handle the main loop for linux', async () => {
     Object.defineProperty(process, "platform", {


### PR DESCRIPTION
The MSYS2 project just added support for `tmate`; Might just as well use
it (especially because the reason `tmate` was added was to support
`action-tmate`).

See https://github.com/msys2/MSYS2-packages/pull/2211 for details about
MSYS2 adding support for `tmate`.

Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>

Original PR: #26