### PR TITLE
replace multiple identical typos with a shared const string

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,5 @@
+import { exitDebugSessionMessage } from "../src/helpers"
+
 module.exports =
 /******/ (() => { // webpackBootstrap
 /******/ 	"use strict";
@@ -498,7 +500,7 @@ async function run() {
 
       const skip = external_fs_default().existsSync(continuePath) || external_fs_default().existsSync(external_path_default().join(process.env.GITHUB_WORKSPACE, "continue"))
       if (skip) {
-        core.info("Existing debugging session because '/continue' file was created")
+        core.info(exitDebugSessionMessage)
         break
       }
       await sleep(5000)

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -28,3 +28,5 @@ export const execShellCommand = (cmd) => {
     });
   });
 }
+
+export const exitDebugSessionMessage = "Exiting debugging session because '/continue' file was created"

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ import fs from "fs"
 import path from "path"
 import * as core from "@actions/core"
 
-import { execShellCommand } from "./helpers"
+import { execShellCommand, exitDebugSessionMessage } from "./helpers"
 
 const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms));
 
@@ -47,7 +47,7 @@ export async function run() {
 
       const skip = fs.existsSync(continuePath) || fs.existsSync(path.join(process.env.GITHUB_WORKSPACE, "continue"))
       if (skip) {
-        core.info("Existing debugging session because '/continue' file was created")
+        core.info(exitDebugSessionMessage)
         break
       }
       await sleep(5000)

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,5 +1,6 @@
 jest.mock('@actions/core');
 import * as core from "@actions/core"
+import { exitDebugSessionMessage } from "./helpers"
 
 jest.mock("fs", () => ({
   mkdirSync: () => true,
@@ -29,7 +30,7 @@ describe('Tmate GitHub integration', () => {
     expect(execShellCommand).toHaveBeenNthCalledWith(1, "pacman -Sy --noconfirm tmate")
     expect(core.info).toHaveBeenNthCalledWith(1, `WebURL: ${customConnectionString}`);
     expect(core.info).toHaveBeenNthCalledWith(2, `SSH: ${customConnectionString}`);
-    expect(core.info).toHaveBeenNthCalledWith(3, "Existing debugging session because '/continue' file was created");
+    expect(core.info).toHaveBeenNthCalledWith(3, exitDebugSessionMessage);
   });
   it('should be handle the main loop for linux', async () => {
     Object.defineProperty(process, "platform", {
@@ -42,7 +43,7 @@ describe('Tmate GitHub integration', () => {
     expect(execShellCommand).toHaveBeenNthCalledWith(1, "sudo apt-get update")
     expect(core.info).toHaveBeenNthCalledWith(1, `WebURL: ${customConnectionString}`);
     expect(core.info).toHaveBeenNthCalledWith(2, `SSH: ${customConnectionString}`);
-    expect(core.info).toHaveBeenNthCalledWith(3, "Existing debugging session because '/continue' file was created");
+    expect(core.info).toHaveBeenNthCalledWith(3, exitDebugSessionMessage);
   });
   it('should be handle the main loop for linux without sudo', async () => {
     Object.defineProperty(process, "platform", {
@@ -55,7 +56,7 @@ describe('Tmate GitHub integration', () => {
     expect(execShellCommand).toHaveBeenNthCalledWith(1, "apt-get update")
     expect(core.info).toHaveBeenNthCalledWith(1, `WebURL: ${customConnectionString}`);
     expect(core.info).toHaveBeenNthCalledWith(2, `SSH: ${customConnectionString}`);
-    expect(core.info).toHaveBeenNthCalledWith(3, "Existing debugging session because '/continue' file was created");
+    expect(core.info).toHaveBeenNthCalledWith(3, exitDebugSessionMessage);
   });
   it('should install tmate via brew for darwin', async () => {
     Object.defineProperty(process, "platform", {


### PR DESCRIPTION
I noticed while using this action that upon `touch continue`, you receive in the action console the following message:

```
Existing debugging session because '/continue' file was created
```

Which appears to have meant to read:

```
Exiting debugging session because '/continue' file was created
```

When I looked into the source code to fix this typo, I came across 5 or so separate instances of this misspelled string, leading me to believe this is the result of an inadvertent copy/paste.

I added `exitDebugSessionMessage` to `src/helpers.js` to both correct the typo, and to prevent future misspellings or inconsistencies if this message is ever refactored.

---

All existing tests were re-run and verified to be passing prior to the creation of this PR.