### PR TITLE
README: fix `timeout-minutes` example

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ jobs:
     - uses: actions/checkout@v2
     - name: Setup tmate session
       uses: mxschmitt/action-tmate@v3
-      timeout-minutes: 15
+      with:
+        timeout-minutes: 15
 ```
 
 ## Continue a workflow


### PR DESCRIPTION
The example was incorrect, we need to use `with:` to specify inputs.