### PR TITLE
fix(win): relative continue path check and CWD

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -9634,6 +9634,11 @@ async function run() {
       await execShellCommand('brew install tmate');
     } else if (process.platform === "win32") {
       await execShellCommand('pacman -Sy --noconfirm tmate');
+
+      const bashProfilePath = "C:\\msys64\\etc\\profile"
+      let bashProfileContent = external_fs_default().readFileSync(bashProfilePath).toString()
+      bashProfileContent += '\ncd "${GITHUB_WORKSPACE}"\n'
+      external_fs_default().writeFileSync(bashProfilePath, bashProfileContent)
     } else {
       await execShellCommand(optionalSudoPrefix + 'apt-get update');
       await execShellCommand(optionalSudoPrefix + 'apt-get install -y openssh-client');
@@ -9691,7 +9696,7 @@ async function run() {
       core.info(`SSH: ${tmateSSH}`);
 
       if (continueFileExists()) {
-        core.info("Exiting debugging session because '/continue' file was created")
+        core.info("Exiting debugging session because the continue file was created")
         break
       }
 
@@ -9704,8 +9709,8 @@ async function run() {
 }
 
 function continueFileExists() {
-  const continuePath = process.platform !== "win32" ? "/continue" : "C:/msys64/continue"
-  return external_fs_default().existsSync(continuePath) || external_fs_default().existsSync(external_path_default().join(process.env.GITHUB_WORKSPACE, "continue"))
+  const rootDirContinuePath = process.platform === "win32" ? "C:/msys64/continue" : "/continue"
+  return external_fs_default().existsSync(rootDirContinuePath) || external_fs_default().existsSync(external_path_default().join(process.env.GITHUB_WORKSPACE, "continue"))
 }
 // CONCATENATED MODULE: ./src/main.js
 

--- a/src/index.js
+++ b/src/index.js
@@ -23,6 +23,11 @@ export async function run() {
       await execShellCommand('brew install tmate');
     } else if (process.platform === "win32") {
       await execShellCommand('pacman -Sy --noconfirm tmate');
+
+      const bashProfilePath = "C:\\msys64\\etc\\profile"
+      let bashProfileContent = fs.readFileSync(bashProfilePath).toString()
+      bashProfileContent += '\ncd "${GITHUB_WORKSPACE}"\n'
+      fs.writeFileSync(bashProfilePath, bashProfileContent)
     } else {
       await execShellCommand(optionalSudoPrefix + 'apt-get update');
       await execShellCommand(optionalSudoPrefix + 'apt-get install -y openssh-client');
@@ -80,7 +85,7 @@ export async function run() {
       core.info(`SSH: ${tmateSSH}`);
 
       if (continueFileExists()) {
-        core.info("Exiting debugging session because '/continue' file was created")
+        core.info("Exiting debugging session because the continue file was created")
         break
       }
 
@@ -93,6 +98,6 @@ export async function run() {
 }
 
 function continueFileExists() {
-  const continuePath = process.platform !== "win32" ? "/continue" : "C:/msys64/continue"
-  return fs.existsSync(continuePath) || fs.existsSync(path.join(process.env.GITHUB_WORKSPACE, "continue"))
+  const rootDirContinuePath = process.platform === "win32" ? "C:/msys64/continue" : "/continue"
+  return fs.existsSync(rootDirContinuePath) || fs.existsSync(path.join(process.env.GITHUB_WORKSPACE, "continue"))
 }

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -7,7 +7,9 @@ jest.mock("@actions/tool-cache", () => ({
 }));
 jest.mock("fs", () => ({
   mkdirSync: () => true,
-  existsSync: () => true
+  existsSync: () => true,
+  readFileSync: () => "",
+  writeFileSync: () => true
 }));
 jest.mock('./helpers');
 import { execShellCommand } from "./helpers"
@@ -33,7 +35,7 @@ describe('Tmate GitHub integration', () => {
     expect(execShellCommand).toHaveBeenNthCalledWith(1, "pacman -Sy --noconfirm tmate")
     expect(core.info).toHaveBeenNthCalledWith(1, `Web shell: ${customConnectionString}`);
     expect(core.info).toHaveBeenNthCalledWith(2, `SSH: ${customConnectionString}`);
-    expect(core.info).toHaveBeenNthCalledWith(3, "Exiting debugging session because '/continue' file was created");
+    expect(core.info).toHaveBeenNthCalledWith(3, "Exiting debugging session because the continue file was created");
   });
   it('should be handle the main loop for linux', async () => {
     Object.defineProperty(process, "platform", {
@@ -46,7 +48,7 @@ describe('Tmate GitHub integration', () => {
     expect(execShellCommand).toHaveBeenNthCalledWith(1, "sudo apt-get update")
     expect(core.info).toHaveBeenNthCalledWith(1, `Web shell: ${customConnectionString}`);
     expect(core.info).toHaveBeenNthCalledWith(2, `SSH: ${customConnectionString}`);
-    expect(core.info).toHaveBeenNthCalledWith(3, "Exiting debugging session because '/continue' file was created");
+    expect(core.info).toHaveBeenNthCalledWith(3, "Exiting debugging session because the continue file was created");
   });
   it('should be handle the main loop for linux without sudo', async () => {
     Object.defineProperty(process, "platform", {
@@ -59,7 +61,7 @@ describe('Tmate GitHub integration', () => {
     expect(execShellCommand).toHaveBeenNthCalledWith(1, "apt-get update")
     expect(core.info).toHaveBeenNthCalledWith(1, `Web shell: ${customConnectionString}`);
     expect(core.info).toHaveBeenNthCalledWith(2, `SSH: ${customConnectionString}`);
-    expect(core.info).toHaveBeenNthCalledWith(3, "Exiting debugging session because '/continue' file was created");
+    expect(core.info).toHaveBeenNthCalledWith(3, "Exiting debugging session because the continue file was created");
   });
   it('should install tmate via brew for darwin', async () => {
     Object.defineProperty(process, "platform", {


### PR DESCRIPTION
Fixed that the continue file was not recognised when you created it in the home directory of the msys64 session.