### PR TITLE
fix: only print web shell when persistent

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -9683,7 +9683,9 @@ async function run() {
 
     console.debug("Entering main loop")
     while (true) {
-      core.info(`Web shell: ${tmateWeb}`);
+      if (tmateWeb) {
+        core.info(`Web shell: ${tmateWeb}`);
+      }
       core.info(`SSH: ${tmateSSH}`);
 
       if (continueFileExists()) {

--- a/src/index.js
+++ b/src/index.js
@@ -74,7 +74,9 @@ export async function run() {
 
     console.debug("Entering main loop")
     while (true) {
-      core.info(`Web shell: ${tmateWeb}`);
+      if (tmateWeb) {
+        core.info(`Web shell: ${tmateWeb}`);
+      }
       core.info(`SSH: ${tmateSSH}`);
 
       if (continueFileExists()) {


### PR DESCRIPTION
When using `limit-access-to-actor` the web shell is not persistent. With this change, we only print it when its there.

Fixes #44