### PR TITLE
Also continue when the tmate socket was deleted

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -9695,12 +9695,22 @@ async function run() {
         break
       }
 
+      if (didTmateQuit()) {
+        core.info("Exiting debugging session 'tmate' quit")
+        break
+      }
+
       await sleep(5000)
     }
 
   } catch (error) {
     core.setFailed(error);
   }
+}
+
+function didTmateQuit() {
+  const tmateSocketPath = process.platform === "win32" ? "C:/msys64/tmp/tmate.sock" : "/tmp/tmate.sock"
+  return !external_fs_default().existsSync(tmateSocketPath)
 }
 
 function continueFileExists() {

--- a/src/index.js
+++ b/src/index.js
@@ -84,12 +84,22 @@ export async function run() {
         break
       }
 
+      if (didTmateQuit()) {
+        core.info("Exiting debugging session 'tmate' quit")
+        break
+      }
+
       await sleep(5000)
     }
 
   } catch (error) {
     core.setFailed(error);
   }
+}
+
+function didTmateQuit() {
+  const tmateSocketPath = process.platform === "win32" ? "C:/msys64/tmp/tmate.sock" : "/tmp/tmate.sock"
+  return !fs.existsSync(tmateSocketPath)
 }
 
 function continueFileExists() {


### PR DESCRIPTION
I stumbled across this during a debugging session: when I quit the shell inside the `tmate` session, the SSH session went with it, too, and I could no longer connect. Yet the Action still was running, waiting for a `continue` file to be created.

Let's just treat the absence of a `tmate` session the same as the presence of that `continue` file: the user wants the workflow to move on.