### PR TITLE
fix: remove tmate executable if already exists

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -9642,8 +9642,12 @@ async function run() {
       const tmateReleaseTar = await tool_cache.downloadTool(`https://github.com/tmate-io/tmate/releases/download/${TMATE_LINUX_VERSION}/tmate-${TMATE_LINUX_VERSION}-static-linux-amd64.tar.xz`);
       const tmateDir = external_path_default().join(external_os_default().tmpdir(), "tmate")
       tmateExecutable = external_path_default().join(tmateDir, "tmate")
-      external_fs_default().mkdirSync(tmateDir)
+
+      if (external_fs_default().existsSync(tmateExecutable))
+        external_fs_default().rmdirSync(tmateExecutable)
+      external_fs_default().mkdirSync(tmateDir, { recursive: true })
       await execShellCommand(`tar x -C ${tmateDir} -f ${tmateReleaseTar} --strip-components=1`)
+      external_fs_default().rmdirSync(tmateReleaseTar)
     }
 
     core.debug("Installed dependencies successfully");

--- a/src/index.js
+++ b/src/index.js
@@ -31,8 +31,12 @@ export async function run() {
       const tmateReleaseTar = await tc.downloadTool(`https://github.com/tmate-io/tmate/releases/download/${TMATE_LINUX_VERSION}/tmate-${TMATE_LINUX_VERSION}-static-linux-amd64.tar.xz`);
       const tmateDir = path.join(os.tmpdir(), "tmate")
       tmateExecutable = path.join(tmateDir, "tmate")
-      fs.mkdirSync(tmateDir)
+
+      if (fs.existsSync(tmateExecutable))
+        fs.rmdirSync(tmateExecutable)
+      fs.mkdirSync(tmateDir, { recursive: true })
       await execShellCommand(`tar x -C ${tmateDir} -f ${tmateReleaseTar} --strip-components=1`)
+      fs.rmdirSync(tmateReleaseTar)
     }
 
     core.debug("Installed dependencies successfully");

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -7,7 +7,8 @@ jest.mock("@actions/tool-cache", () => ({
 }));
 jest.mock("fs", () => ({
   mkdirSync: () => true,
-  existsSync: () => true
+  existsSync: () => true,
+  rmdirSync: () => true,
 }));
 jest.mock('./helpers');
 import { execShellCommand } from "./helpers"


### PR DESCRIPTION
Fixed two potential issues:
a) on self-hosted runners when the tmp directory does not get cleaned up
the tmate executable stays there, we fix this by removing if it exists
to ensure we have the latest version.
#59
b) We cleanup the tmate release tar after we extracted it