### PR TITLE
Turn `errexit` off in the shell sessions

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -9679,14 +9679,20 @@ async function run() {
       newSessionExtra = `-a "${authorizedKeysPath}"`
     }
 
+    const tmate = `${tmateExecutable} -S /tmp/tmate.sock`;
+
+    // Work around potential `set -e` commands in `~/.profile` (looking at you, `setup-miniconda`!)
+    external_fs_default().writeFileSync('/tmp/tmate.bashrc', 'set +e\n');
+    const setDefaultCommand = `set-option -g default-command "bash --rcfile /tmp/tmate.bashrc" \\;`;
+
     core.debug("Creating new session")
-    await execShellCommand(`${tmateExecutable} -S /tmp/tmate.sock ${newSessionExtra} new-session -d`);
-    await execShellCommand(`${tmateExecutable} -S /tmp/tmate.sock wait tmate-ready`);
+    await execShellCommand(`${tmate} ${setDefaultCommand} ${newSessionExtra} new-session -d`);
+    await execShellCommand(`${tmate} wait tmate-ready`);
     console.debug("Created new session successfully")
 
     core.debug("Fetching connection strings")
-    const tmateSSH = await execShellCommand(`${tmateExecutable} -S /tmp/tmate.sock display -p '#{tmate_ssh}'`);
-    const tmateWeb = await execShellCommand(`${tmateExecutable} -S /tmp/tmate.sock display -p '#{tmate_web}'`);
+    const tmateSSH = await execShellCommand(`${tmate} display -p '#{tmate_ssh}'`);
+    const tmateWeb = await execShellCommand(`${tmate} display -p '#{tmate_web}'`);
 
     console.debug("Entering main loop")
     while (true) {

--- a/src/index.js
+++ b/src/index.js
@@ -68,14 +68,16 @@ export async function run() {
       newSessionExtra = `-a "${authorizedKeysPath}"`
     }
 
+    const tmate = `${tmateExecutable} -S /tmp/tmate.sock`;
+
     core.debug("Creating new session")
-    await execShellCommand(`${tmateExecutable} -S /tmp/tmate.sock ${newSessionExtra} new-session -d`);
-    await execShellCommand(`${tmateExecutable} -S /tmp/tmate.sock wait tmate-ready`);
+    await execShellCommand(`${tmate} ${newSessionExtra} new-session -d`);
+    await execShellCommand(`${tmate} wait tmate-ready`);
     console.debug("Created new session successfully")
 
     core.debug("Fetching connection strings")
-    const tmateSSH = await execShellCommand(`${tmateExecutable} -S /tmp/tmate.sock display -p '#{tmate_ssh}'`);
-    const tmateWeb = await execShellCommand(`${tmateExecutable} -S /tmp/tmate.sock display -p '#{tmate_web}'`);
+    const tmateSSH = await execShellCommand(`${tmate} display -p '#{tmate_ssh}'`);
+    const tmateWeb = await execShellCommand(`${tmate} display -p '#{tmate_web}'`);
 
     console.debug("Entering main loop")
     while (true) {

--- a/src/index.js
+++ b/src/index.js
@@ -70,8 +70,12 @@ export async function run() {
 
     const tmate = `${tmateExecutable} -S /tmp/tmate.sock`;
 
+    // Work around potential `set -e` commands in `~/.profile` (looking at you, `setup-miniconda`!)
+    fs.writeFileSync('/tmp/tmate.bashrc', 'set +e\n');
+    const setDefaultCommand = `set-option -g default-command "bash --rcfile /tmp/tmate.bashrc" \\;`;
+
     core.debug("Creating new session")
-    await execShellCommand(`${tmate} ${newSessionExtra} new-session -d`);
+    await execShellCommand(`${tmate} ${setDefaultCommand} ${newSessionExtra} new-session -d`);
     await execShellCommand(`${tmate} wait tmate-ready`);
     console.debug("Created new session successfully")
 

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -9,6 +9,7 @@ jest.mock("fs", () => ({
   mkdirSync: () => true,
   existsSync: () => true,
   unlinkSync: () => true,
+  writeFileSync: () => true
 }));
 jest.mock('./helpers');
 import { execShellCommand } from "./helpers"


### PR DESCRIPTION
When `errexit` is turned on (e.g. via `set -e` in the Bash profile), even a simple typo will take the entire shell session with it. Usually, it is not set (except on macOS), but the `setup-miniconda` Action seems to append it to the Bash profile, probably assuming that it won't hurt because nobody is running GitHub workflows interactively (except we do, with `action-tmate`...).

That's not what we want, therefore let's turn it off specifically.

This fixes https://github.com/mxschmitt/action-tmate/issues/37.