### PR TITLE
fix: limit-access-to-actor functionality

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -9686,7 +9686,7 @@ async function run() {
     const setDefaultCommand = `set-option -g default-command "bash --rcfile /tmp/tmate.bashrc" \\;`;
 
     core.debug("Creating new session")
-    await execShellCommand(`${tmate} ${setDefaultCommand} ${newSessionExtra} new-session -d`);
+    await execShellCommand(`${tmate} ${newSessionExtra} ${setDefaultCommand} new-session -d`);
     await execShellCommand(`${tmate} wait tmate-ready`);
     console.debug("Created new session successfully")
 

--- a/src/index.js
+++ b/src/index.js
@@ -75,7 +75,7 @@ export async function run() {
     const setDefaultCommand = `set-option -g default-command "bash --rcfile /tmp/tmate.bashrc" \\;`;
 
     core.debug("Creating new session")
-    await execShellCommand(`${tmate} ${setDefaultCommand} ${newSessionExtra} new-session -d`);
+    await execShellCommand(`${tmate} ${newSessionExtra} ${setDefaultCommand} new-session -d`);
     await execShellCommand(`${tmate} wait tmate-ready`);
     console.debug("Created new session successfully")
 


### PR DESCRIPTION
This was a regression introduced in #64 which broke the limit-access-to-actor functionality.

The order of the input parameters seems important, since first the parameters from tmate come and then from tmux.

Fixes #65

tested with:

```
name: CI
on: [push]
jobs:
  test:
    runs-on: ubuntu-latest
    name: test
    steps:
    - uses: actions/checkout@v2
    - name: Setup tmate session
      uses: mxschmitt/action-tmate@bugfix/limit-access-to-actor
      with:
        limit-access-to-actor: true
```