### PR TITLE
Fix for VS2019

### DIFF
--- a/.github/workflows/manual-test.yml
+++ b/.github/workflows/manual-test.yml
@@ -1,0 +1,24 @@
+name: Manual test matrix
+on: workflow_dispatch
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        runs-on:
+          - ubuntu-16.04
+          - ubuntu-18.04
+          - ubuntu-20.04
+          - macos-10.15
+          - macos-11.0
+          - windows-2019
+        limit-access-to-actor:
+          - true
+          - false
+    runs-on: ${{ matrix.runs-on }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./
+        with:
+          limit-access-to-actor: ${{ matrix.limit-access-to-actor }}

--- a/lib/index.js
+++ b/lib/index.js
@@ -9682,7 +9682,7 @@ async function run() {
     const tmate = `${tmateExecutable} -S /tmp/tmate.sock`;
 
     // Work around potential `set -e` commands in `~/.profile` (looking at you, `setup-miniconda`!)
-    external_fs_default().writeFileSync('/tmp/tmate.bashrc', 'set +e\n');
+    await execShellCommand(`echo 'set +e' >/tmp/tmate.bashrc`);
     const setDefaultCommand = `set-option -g default-command "bash --rcfile /tmp/tmate.bashrc" \\;`;
 
     core.debug("Creating new session")

--- a/src/index.js
+++ b/src/index.js
@@ -71,7 +71,7 @@ export async function run() {
     const tmate = `${tmateExecutable} -S /tmp/tmate.sock`;
 
     // Work around potential `set -e` commands in `~/.profile` (looking at you, `setup-miniconda`!)
-    fs.writeFileSync('/tmp/tmate.bashrc', 'set +e\n');
+    await execShellCommand(`echo 'set +e' >/tmp/tmate.bashrc`);
     const setDefaultCommand = `set-option -g default-command "bash --rcfile /tmp/tmate.bashrc" \\;`;
 
     core.debug("Creating new session")


### PR DESCRIPTION
D'oh! In my recent workaround, I totally forgot that on Windows, `/tmp` is not equal to `/tmp`...

This fixes that, and it also adds a (manual) workflow that can be used for interactive testing.

This fixes https://github.com/mxschmitt/action-tmate/issues/67