### PR TITLE
add option to skip dependency installation

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,10 @@ inputs:
     description: 'If apt should be executed with sudo or without'
     required: false
     default: 'true'
+  install_dependencies:
+    description: 'Whether or not to install dependencies for tmate on linux (openssh-client, xz-utils)'
+    required: false
+    default: 'true'
   limit-access-to-actor:
     description: 'If only the public SSH keys of the user triggering the workflow should be authorized'
     required: false

--- a/lib/index.js
+++ b/lib/index.js
@@ -9625,6 +9625,11 @@ const TMATE_LINUX_VERSION = "2.4.0"
 /** @param {number} ms */
 const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms));
 
+async function installDependenciesLinux(optionalSudoPrefix='sudo') {
+  await execShellCommand(optionalSudoPrefix + 'apt-get update');
+  await execShellCommand(optionalSudoPrefix + 'apt-get install -y openssh-client xz-utils');
+}
+
 async function run() {
   const optionalSudoPrefix = core.getInput('sudo') === "true" ? "sudo " : "";
   try {
@@ -9636,9 +9641,9 @@ async function run() {
       await execShellCommand('pacman -Sy --noconfirm tmate');
       tmateExecutable = 'CHERE_INVOKING=1 tmate'
     } else {
-      await execShellCommand(optionalSudoPrefix + 'apt-get update');
-      await execShellCommand(optionalSudoPrefix + 'apt-get install -y openssh-client xz-utils');
-
+      if (core.getInput('install_dependencies') === "true") {
+        await installDependenciesLinux(optionalSudoPrefix);
+      }
       const tmateReleaseTar = await tool_cache.downloadTool(`https://github.com/tmate-io/tmate/releases/download/${TMATE_LINUX_VERSION}/tmate-${TMATE_LINUX_VERSION}-static-linux-amd64.tar.xz`);
       const tmateDir = external_path_default().join(external_os_default().tmpdir(), "tmate")
       tmateExecutable = external_path_default().join(tmateDir, "tmate")
@@ -9728,6 +9733,7 @@ function continueFileExists() {
   const continuePath = process.platform === "win32" ? "C:/msys64/continue" : "/continue"
   return external_fs_default().existsSync(continuePath) || external_fs_default().existsSync(external_path_default().join(process.env.GITHUB_WORKSPACE, "continue"))
 }
+
 // CONCATENATED MODULE: ./src/main.js
 
 

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,11 @@ const TMATE_LINUX_VERSION = "2.4.0"
 /** @param {number} ms */
 const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms));
 
+export async function installDependenciesLinux(optionalSudoPrefix='sudo') {
+  await execShellCommand(optionalSudoPrefix + 'apt-get update');
+  await execShellCommand(optionalSudoPrefix + 'apt-get install -y openssh-client xz-utils');
+}
+
 export async function run() {
   const optionalSudoPrefix = core.getInput('sudo') === "true" ? "sudo " : "";
   try {
@@ -25,9 +30,9 @@ export async function run() {
       await execShellCommand('pacman -Sy --noconfirm tmate');
       tmateExecutable = 'CHERE_INVOKING=1 tmate'
     } else {
-      await execShellCommand(optionalSudoPrefix + 'apt-get update');
-      await execShellCommand(optionalSudoPrefix + 'apt-get install -y openssh-client xz-utils');
-
+      if (core.getInput('install_dependencies') === "true") {
+        await installDependenciesLinux(optionalSudoPrefix);
+      }
       const tmateReleaseTar = await tc.downloadTool(`https://github.com/tmate-io/tmate/releases/download/${TMATE_LINUX_VERSION}/tmate-${TMATE_LINUX_VERSION}-static-linux-amd64.tar.xz`);
       const tmateDir = path.join(os.tmpdir(), "tmate")
       tmateExecutable = path.join(tmateDir, "tmate")

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -41,7 +41,7 @@ describe('Tmate GitHub integration', () => {
     Object.defineProperty(process, "platform", {
       value: "linux"
     })
-    core.getInput.mockReturnValueOnce("true").mockReturnValue("false")
+    core.getInput.mockReturnValueOnce("true").mockReturnValueOnce("true").mockReturnValue("false")
     const customConnectionString = "foobar"
     execShellCommand.mockReturnValue(Promise.resolve(customConnectionString))
     await run()
@@ -54,11 +54,24 @@ describe('Tmate GitHub integration', () => {
     Object.defineProperty(process, "platform", {
       value: "linux"
     })
-    core.getInput.mockReturnValue("false")
+    core.getInput.mockReturnValueOnce("false").mockReturnValueOnce("true").mockReturnValue("false")
     const customConnectionString = "foobar"
     execShellCommand.mockReturnValue(Promise.resolve(customConnectionString))
     await run()
     expect(execShellCommand).toHaveBeenNthCalledWith(1, "apt-get update")
+    expect(core.info).toHaveBeenNthCalledWith(1, `Web shell: ${customConnectionString}`);
+    expect(core.info).toHaveBeenNthCalledWith(2, `SSH: ${customConnectionString}`);
+    expect(core.info).toHaveBeenNthCalledWith(3, "Exiting debugging session because the continue file was created");
+  });
+  it('should be handle the main loop for linux without installing dependencies', async () => {
+    Object.defineProperty(process, "platform", {
+      value: "linux"
+    })
+    core.getInput.mockReturnValue("false")
+    const customConnectionString = "foobar"
+    execShellCommand.mockReturnValue(Promise.resolve(customConnectionString))
+    await run()
+    expect(execShellCommand).not.toHaveBeenNthCalledWith(1, "apt-get update")
     expect(core.info).toHaveBeenNthCalledWith(1, `Web shell: ${customConnectionString}`);
     expect(core.info).toHaveBeenNthCalledWith(2, `SSH: ${customConnectionString}`);
     expect(core.info).toHaveBeenNthCalledWith(3, "Exiting debugging session because the continue file was created");


### PR DESCRIPTION
apt-get is not available on certain distributions so it's better to have
the option to leave it out so we can still have the ability to run this
action without having to be on ubuntu.

Indirectly helps resolve #54 