### PR TITLE
Fix Jekyll formatting of code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ on:
 
 Then add an [`if`](https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions) condition to the debug step:
 
+<!--
+{% raw %}
+-->
 ```yaml
 jobs:
   build:
@@ -64,6 +67,9 @@ jobs:
         uses: mxschmitt/action-tmate@v3
         if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled }}
 ```
+<!--
+{% endraw %}
+-->
 
 You can then [manually run a workflow](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow) on the desired branch and set `debug_enabled` to true to get a debug session.
 


### PR DESCRIPTION
As I noted in [this][1] comment on #78, the formatting on the [Jekyll generated page][2] is wrong as
(I think) it's interpreting the `${{ ... }}` as a Liquid tag.

We need to wrap the code block in a [`{% raw %} .. {% endraw %}`][3], but the only way I could think
of doing this without it being visible in the GitHub markdown was to enclose it in a standard HTML
comment. Hacky, but seems to work!

[1]: https://github.com/mxschmitt/action-tmate/pull/78#issuecomment-821243039
[2]: https://mxschmitt.github.io/action-tmate/
[3]: https://blog.slaks.net/2013-06-10/jekyll-endraw-in-code/