### PR TITLE
Select tmate binaries based on CPU architecture

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -10291,6 +10291,16 @@ const execShellCommand = (cmd) => {
 
 const TMATE_LINUX_VERSION = "2.4.0"
 
+// Map os.arch() values to the architectures in tmate release binary filenames.
+// Possible os.arch() values documented here:
+// https://nodejs.org/api/os.html#os_os_arch
+// Available tmate binaries listed here:
+// https://github.com/tmate-io/tmate/releases/
+const TMATE_ARCH_MAP = {
+  arm64: 'arm64v8',
+  x64: 'amd64',
+};
+
 /** @param {number} ms */
 const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms));
 
@@ -10308,23 +10318,10 @@ async function run() {
       await execShellCommand(optionalSudoPrefix + 'apt-get update');
       await execShellCommand(optionalSudoPrefix + 'apt-get install -y openssh-client xz-utils');
 
-      // Possible os.arch() values documented here:
-      // https://nodejs.org/api/os.html#os_os_arch
-      // Available tmate binaries listed here:
-      // https://github.com/tmate-io/tmate/releases/
-      let tmateArch;
-      switch (external_os_default().arch()) {
-        case 'arm64':
-          tmateArch = 'arm64v8';
-          break;
-        case 'x64':
-          tmateArch = 'amd64';
-          break;
-        default:
-          throw new Error(`Unsupported architecture: ${external_os_default().arch()}`)
-          break;
+      const tmateArch = TMATE_ARCH_MAP[external_os_default().arch()];
+      if (!tmateArch) {
+        throw new Error(`Unsupported architecture: ${external_os_default().arch()}`)
       }
-
       const tmateReleaseTar = await tool_cache.downloadTool(`https://github.com/tmate-io/tmate/releases/download/${TMATE_LINUX_VERSION}/tmate-${TMATE_LINUX_VERSION}-static-linux-${tmateArch}.tar.xz`);
       const tmateDir = external_path_default().join(external_os_default().tmpdir(), "tmate")
       tmateExecutable = external_path_default().join(tmateDir, "tmate")

--- a/lib/index.js
+++ b/lib/index.js
@@ -10308,7 +10308,24 @@ async function run() {
       await execShellCommand(optionalSudoPrefix + 'apt-get update');
       await execShellCommand(optionalSudoPrefix + 'apt-get install -y openssh-client xz-utils');
 
-      const tmateReleaseTar = await tool_cache.downloadTool(`https://github.com/tmate-io/tmate/releases/download/${TMATE_LINUX_VERSION}/tmate-${TMATE_LINUX_VERSION}-static-linux-amd64.tar.xz`);
+      // Possible os.arch() values documented here:
+      // https://nodejs.org/api/os.html#os_os_arch
+      // Available tmate binaries listed here:
+      // https://github.com/tmate-io/tmate/releases/
+      let tmateArch;
+      switch (external_os_default().arch()) {
+        case 'arm64':
+          tmateArch = 'arm64v8';
+          break;
+        case 'x64':
+          tmateArch = 'amd64';
+          break;
+        default:
+          throw new Error(`Unsupported architecture: ${external_os_default().arch()}`)
+          break;
+      }
+
+      const tmateReleaseTar = await tool_cache.downloadTool(`https://github.com/tmate-io/tmate/releases/download/${TMATE_LINUX_VERSION}/tmate-${TMATE_LINUX_VERSION}-static-linux-${tmateArch}.tar.xz`);
       const tmateDir = external_path_default().join(external_os_default().tmpdir(), "tmate")
       tmateExecutable = external_path_default().join(tmateDir, "tmate")
 

--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,24 @@ export async function run() {
       await execShellCommand(optionalSudoPrefix + 'apt-get update');
       await execShellCommand(optionalSudoPrefix + 'apt-get install -y openssh-client xz-utils');
 
-      const tmateReleaseTar = await tc.downloadTool(`https://github.com/tmate-io/tmate/releases/download/${TMATE_LINUX_VERSION}/tmate-${TMATE_LINUX_VERSION}-static-linux-amd64.tar.xz`);
+      // Possible os.arch() values documented here:
+      // https://nodejs.org/api/os.html#os_os_arch
+      // Available tmate binaries listed here:
+      // https://github.com/tmate-io/tmate/releases/
+      let tmateArch;
+      switch (os.arch()) {
+        case 'arm64':
+          tmateArch = 'arm64v8';
+          break;
+        case 'x64':
+          tmateArch = 'amd64';
+          break;
+        default:
+          throw new Error(`Unsupported architecture: ${os.arch()}`)
+          break;
+      }
+
+      const tmateReleaseTar = await tc.downloadTool(`https://github.com/tmate-io/tmate/releases/download/${TMATE_LINUX_VERSION}/tmate-${TMATE_LINUX_VERSION}-static-linux-${tmateArch}.tar.xz`);
       const tmateDir = path.join(os.tmpdir(), "tmate")
       tmateExecutable = path.join(tmateDir, "tmate")
 


### PR DESCRIPTION
Now arm64 and amd64 are both supported.

Closes #90