### PR TITLE
Support user own tmate server

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,27 @@ jobs:
 
 If the registered public SSH key is not your default private SSH key, you will need to specify the path manually, like so: `ssh -i <path-to-key> <tmate-connection-string>`.
 
+## Use your own tmate servers
+
+By default the tmate session use `ssh.tmate.io`. You can use your own tmate servers. [tmate-ssh-server](https://github.com/tmate-io/tmate-ssh-server) is the server side part of tmate.
+
+```yaml
+name: CI
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup tmate session
+      uses: mxschmitt/action-tmate@v3
+      with:
+        tmate-server-host: ssh.tmate.io
+        tmate-server-port: 22
+        tmate-server-rsa-fingerprint: SHA256:Hthk2T/M/Ivqfk1YYUn5ijC2Att3+UPzD7Rn72P5VWs
+        tmate-server-ed25519-fingerprint: SHA256:jfttvoypkHiQYUqUCwKeqd9d1fJj/ZiQlFOHVl6E9sI
+```
+
 ## Continue a workflow
 
 If you want to continue a workflow and you are inside a tmate session, just create a empty file with the name `continue` either in the root directory or in the project directory by running `touch continue` or `sudo touch /continue`.

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ If the registered public SSH key is not your default private SSH key, you will n
 
 ## Use your own tmate servers
 
-By default the tmate session use `ssh.tmate.io`. You can use your own tmate servers. [tmate-ssh-server](https://github.com/tmate-io/tmate-ssh-server) is the server side part of tmate.
+By default the tmate session uses `ssh.tmate.io`. You can use your own tmate servers. [tmate-ssh-server](https://github.com/tmate-io/tmate-ssh-server) is the server side part of tmate.
 
 ```yaml
 name: CI

--- a/action.yml
+++ b/action.yml
@@ -13,3 +13,19 @@ inputs:
     description: 'If only the public SSH keys of the user triggering the workflow should be authorized'
     required: false
     default: 'false'
+  tmate-server-host:
+    description: 'The hostname for your tmate server'
+    required: false
+    default: ''
+  tmate-server-port:
+    description: 'The port for your tmate server'
+    required: false
+    default: ''
+  tmate-server-rsa-fingerprint:
+    description: 'The RSA fingerprint for your tmate server'
+    required: false
+    default: ''
+  tmate-server-ed25519-fingerprint:
+    description: 'The ed25519 fingerprint for your tmate server'
+    required: false
+    default: ''

--- a/lib/index.js
+++ b/lib/index.js
@@ -10283,9 +10283,8 @@ const execShellCommand = (cmd) => {
  * @return {string}
  */
 const getValidatedInput = (key) => {
-	const regex = new RegExp('/^[-.+A-Za-z0-9]*$/')
   const value = core.getInput(key);
-  if (regex.test(value)) {
+  if (/^[-.+A-Za-z0-9]*$/.test(value)) {
     throw new Error(`Invalid value for '${key}': '${value}'`);
   }
   return value;

--- a/lib/index.js
+++ b/lib/index.js
@@ -10277,6 +10277,40 @@ const execShellCommand = (cmd) => {
   });
 }
 
+/**
+ * @param {string} host
+ * @param {string} port
+ * @param {string} rsaFingerprint
+ * @param {string} ed25519Fingerprint
+ * @return {Promise<string>}
+ */
+const helpers_isValidInputOwnServer = (host, port, rsaFingerprint, ed25519Fingerprint) => {
+  return new Promise((resolve, reject) => {
+    if (!host && !port && !rsaFingerprint && !ed25519Fingerprint) {
+      return resolve()
+    };
+
+    // validate port
+    const parsedPort = parseInt(port, 10)
+    if (isNaN(parsedPort)) {
+      return reject(new Error("tmate-server-port is not a valid integer"))
+    } else if (parsedPort < 1 || 65535 < parsedPort) {
+      return reject(new Error("tmate-server-port does not contain a valid range"))
+    };
+
+    // validate fingerprint
+    const validFingerprintPrefix = "SHA256:"
+    if (!rsaFingerprint.startsWith(validFingerprintPrefix)) {
+      return reject(new Error("tmate-server-rsa-fingerprint has no prefix SHA256:"))
+    };
+    if (!ed25519Fingerprint.startsWith(validFingerprintPrefix)) {
+      return reject(new Error("tmate-server-ed25519-fingerprint has no prefix SHA256:"))
+    };
+
+    return resolve()
+  });
+}
+
 ;// CONCATENATED MODULE: ./src/index.js
 // @ts-check
 
@@ -10307,6 +10341,8 @@ const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms));
 async function run() {
   const optionalSudoPrefix = core.getInput('sudo') === "true" ? "sudo " : "";
   try {
+    await isValidInputOwnServer(core.getInput("tmate-server-host"), core.getInput("tmate-server-port"), core.getInput("tmate-server-rsa-fingerprint"), core.getInput("tmate-server-ed25519-fingerprint"));
+
     core.debug("Installing dependencies")
     let tmateExecutable = "tmate"
     if (process.platform === "darwin") {

--- a/lib/index.js
+++ b/lib/index.js
@@ -10368,6 +10368,15 @@ async function run() {
     await execShellCommand(`echo 'set +e' >/tmp/tmate.bashrc`);
     const setDefaultCommand = `set-option -g default-command "bash --rcfile /tmp/tmate.bashrc" \\;`;
 
+    const tmateConfPath = external_path_default().join(external_os_default().homedir(), ".tmate.conf")
+    if (core.getInput("tmate-server-host") !== "") {
+      core.debug("Configure your tmate server")
+      await execShellCommand(`echo 'set -g tmate-server-host ${core.getInput("tmate-server-host")}' >> ${tmateConfPath}`)
+      await execShellCommand(`echo 'set -g tmate-server-port ${core.getInput("tmate-server-port")}' >> ${tmateConfPath}`)
+      await execShellCommand(`echo 'set -g tmate-server-rsa-fingerprint ${core.getInput("tmate-server-rsa-fingerprint")}' >> ${tmateConfPath}`)
+      await execShellCommand(`echo 'set -g tmate-server-ed25519-fingerprint ${core.getInput("tmate-server-ed25519-fingerprint")}' >> ${tmateConfPath}`)
+    }
+
     core.debug("Creating new session")
     await execShellCommand(`${tmate} ${newSessionExtra} ${setDefaultCommand} new-session -d`);
     await execShellCommand(`${tmate} wait tmate-ready`);
@@ -10411,6 +10420,7 @@ function continueFileExists() {
   const continuePath = process.platform === "win32" ? "C:/msys64/continue" : "/continue"
   return external_fs_default().existsSync(continuePath) || external_fs_default().existsSync(external_path_default().join(process.env.GITHUB_WORKSPACE, "continue"))
 }
+
 ;// CONCATENATED MODULE: ./src/main.js
 
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -10278,6 +10278,10 @@ const execShellCommand = (cmd) => {
   });
 }
 
+/**
+ * @param {string} key
+ * @return {string}
+ */
 const getValidatedInput = (key) => {
 	const regex = new RegExp('/^[-.+A-Za-z0-9]*$/')
   const value = core.getInput(key);

--- a/lib/index.js
+++ b/lib/index.js
@@ -10242,6 +10242,7 @@ var external_child_process_ = __nccwpck_require__(3129);
 // @ts-check
 
 
+
 /**
  * @param {string} cmd
  * @returns {Promise<string>}
@@ -10277,38 +10278,13 @@ const execShellCommand = (cmd) => {
   });
 }
 
-/**
- * @param {string} host
- * @param {string} port
- * @param {string} rsaFingerprint
- * @param {string} ed25519Fingerprint
- * @return {Promise<string>}
- */
-const helpers_isValidInputOwnServer = (host, port, rsaFingerprint, ed25519Fingerprint) => {
-  return new Promise((resolve, reject) => {
-    if (!host && !port && !rsaFingerprint && !ed25519Fingerprint) {
-      return resolve()
-    };
-
-    // validate port
-    const parsedPort = parseInt(port, 10)
-    if (isNaN(parsedPort)) {
-      return reject(new Error("tmate-server-port is not a valid integer"))
-    } else if (parsedPort < 1 || 65535 < parsedPort) {
-      return reject(new Error("tmate-server-port does not contain a valid range"))
-    };
-
-    // validate fingerprint
-    const validFingerprintPrefix = "SHA256:"
-    if (!rsaFingerprint.startsWith(validFingerprintPrefix)) {
-      return reject(new Error("tmate-server-rsa-fingerprint has no prefix SHA256:"))
-    };
-    if (!ed25519Fingerprint.startsWith(validFingerprintPrefix)) {
-      return reject(new Error("tmate-server-ed25519-fingerprint has no prefix SHA256:"))
-    };
-
-    return resolve()
-  });
+const getValidatedInput = (key) => {
+	const regex = new RegExp('/^[-.+A-Za-z0-9]*$/')
+  const value = core.getInput(key);
+  if (regex.test(value)) {
+    throw new Error(`Invalid value for '${key}': '${value}'`);
+  }
+  return value;
 }
 
 ;// CONCATENATED MODULE: ./src/index.js
@@ -10341,8 +10317,6 @@ const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms));
 async function run() {
   const optionalSudoPrefix = core.getInput('sudo') === "true" ? "sudo " : "";
   try {
-    await isValidInputOwnServer(core.getInput("tmate-server-host"), core.getInput("tmate-server-port"), core.getInput("tmate-server-rsa-fingerprint"), core.getInput("tmate-server-ed25519-fingerprint"));
-
     core.debug("Installing dependencies")
     let tmateExecutable = "tmate"
     if (process.platform === "darwin") {
@@ -10405,10 +10379,10 @@ async function run() {
     let setDefaultCommand = `set-option -g default-command "bash --rcfile /tmp/tmate.bashrc" \\;`;
 
     if (core.getInput("tmate-server-host") !== "") {
-      setDefaultCommand = `${setDefaultCommand} set-option -g tmate-server-host "${core.getInput("tmate-server-host")}\;"`;
-      setDefaultCommand = `${setDefaultCommand} set-option -g tmate-server-port "${core.getInput("tmate-server-port")}\;"`;
-      setDefaultCommand = `${setDefaultCommand} set-option -g tmate-server-rsa-fingerprint "${core.getInput("tmate-server-rsa-fingerprint")}\;"`;
-      setDefaultCommand = `${setDefaultCommand} set-option -g tmate-server-ed25519-fingerprint "${core.getInput("tmate-server-ed25519-fingerprint")}\;"`;
+      setDefaultCommand = `${setDefaultCommand} set-option -g tmate-server-host "${getValidatedInput("tmate-server-host")}" \\;`;
+      setDefaultCommand = `${setDefaultCommand} set-option -g tmate-server-port "${getValidatedInput("tmate-server-port")}" \\;`;
+      setDefaultCommand = `${setDefaultCommand} set-option -g tmate-server-rsa-fingerprint "${getValidatedInput("tmate-server-rsa-fingerprint")}" \\;`;
+      setDefaultCommand = `${setDefaultCommand} set-option -g tmate-server-ed25519-fingerprint "${getValidatedInput("tmate-server-ed25519-fingerprint")}" \\;`;
     }
 
     core.debug("Creating new session")

--- a/lib/index.js
+++ b/lib/index.js
@@ -10366,15 +10366,13 @@ async function run() {
 
     // Work around potential `set -e` commands in `~/.profile` (looking at you, `setup-miniconda`!)
     await execShellCommand(`echo 'set +e' >/tmp/tmate.bashrc`);
-    const setDefaultCommand = `set-option -g default-command "bash --rcfile /tmp/tmate.bashrc" \\;`;
+    let setDefaultCommand = `set-option -g default-command "bash --rcfile /tmp/tmate.bashrc" \\;`;
 
-    const tmateConfPath = external_path_default().join(external_os_default().homedir(), ".tmate.conf")
     if (core.getInput("tmate-server-host") !== "") {
-      core.debug("Configure your tmate server")
-      await execShellCommand(`echo 'set -g tmate-server-host ${core.getInput("tmate-server-host")}' >> ${tmateConfPath}`)
-      await execShellCommand(`echo 'set -g tmate-server-port ${core.getInput("tmate-server-port")}' >> ${tmateConfPath}`)
-      await execShellCommand(`echo 'set -g tmate-server-rsa-fingerprint ${core.getInput("tmate-server-rsa-fingerprint")}' >> ${tmateConfPath}`)
-      await execShellCommand(`echo 'set -g tmate-server-ed25519-fingerprint ${core.getInput("tmate-server-ed25519-fingerprint")}' >> ${tmateConfPath}`)
+      setDefaultCommand = `${setDefaultCommand} set-option -g tmate-server-host "${core.getInput("tmate-server-host")}\;"`;
+      setDefaultCommand = `${setDefaultCommand} set-option -g tmate-server-port "${core.getInput("tmate-server-port")}\;"`;
+      setDefaultCommand = `${setDefaultCommand} set-option -g tmate-server-rsa-fingerprint "${core.getInput("tmate-server-rsa-fingerprint")}\;"`;
+      setDefaultCommand = `${setDefaultCommand} set-option -g tmate-server-ed25519-fingerprint "${core.getInput("tmate-server-ed25519-fingerprint")}\;"`;
     }
 
     core.debug("Creating new session")

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -42,9 +42,8 @@ export const execShellCommand = (cmd) => {
  * @return {string}
  */
 export const getValidatedInput = (key) => {
-	const regex = new RegExp('/^[-.+A-Za-z0-9]*$/')
   const value = core.getInput(key);
-  if (regex.test(value)) {
+  if (/^[-.+A-Za-z0-9]*$/.test(value)) {
     throw new Error(`Invalid value for '${key}': '${value}'`);
   }
   return value;

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,5 +1,6 @@
 // @ts-check
 import { spawn } from 'child_process'
+import * as core from "@actions/core"
 
 /**
  * @param {string} cmd
@@ -36,36 +37,11 @@ export const execShellCommand = (cmd) => {
   });
 }
 
-/**
- * @param {string} host
- * @param {string} port
- * @param {string} rsaFingerprint
- * @param {string} ed25519Fingerprint
- * @return {Promise<string>}
- */
-const isValidInputOwnServer = (host, port, rsaFingerprint, ed25519Fingerprint) => {
-  return new Promise((resolve, reject) => {
-    if (!host && !port && !rsaFingerprint && !ed25519Fingerprint) {
-      return resolve()
-    };
-
-    // validate port
-    const parsedPort = parseInt(port, 10)
-    if (isNaN(parsedPort)) {
-      return reject(new Error("tmate-server-port is not a valid integer"))
-    } else if (parsedPort < 1 || 65535 < parsedPort) {
-      return reject(new Error("tmate-server-port does not contain a valid range"))
-    };
-
-    // validate fingerprint
-    const validFingerprintPrefix = "SHA256:"
-    if (!rsaFingerprint.startsWith(validFingerprintPrefix)) {
-      return reject(new Error("tmate-server-rsa-fingerprint has no prefix SHA256:"))
-    };
-    if (!ed25519Fingerprint.startsWith(validFingerprintPrefix)) {
-      return reject(new Error("tmate-server-ed25519-fingerprint has no prefix SHA256:"))
-    };
-
-    return resolve()
-  });
+export const getValidatedInput = (key) => {
+	const regex = new RegExp('/^[-.+A-Za-z0-9]*$/')
+  const value = core.getInput(key);
+  if (regex.test(value)) {
+    throw new Error(`Invalid value for '${key}': '${value}'`);
+  }
+  return value;
 }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -37,6 +37,10 @@ export const execShellCommand = (cmd) => {
   });
 }
 
+/**
+ * @param {string} key
+ * @return {string}
+ */
 export const getValidatedInput = (key) => {
 	const regex = new RegExp('/^[-.+A-Za-z0-9]*$/')
   const value = core.getInput(key);

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -35,3 +35,37 @@ export const execShellCommand = (cmd) => {
     });
   });
 }
+
+/**
+ * @param {string} host
+ * @param {string} port
+ * @param {string} rsaFingerprint
+ * @param {string} ed25519Fingerprint
+ * @return {Promise<string>}
+ */
+const isValidInputOwnServer = (host, port, rsaFingerprint, ed25519Fingerprint) => {
+  return new Promise((resolve, reject) => {
+    if (!host && !port && !rsaFingerprint && !ed25519Fingerprint) {
+      return resolve()
+    };
+
+    // validate port
+    const parsedPort = parseInt(port, 10)
+    if (isNaN(parsedPort)) {
+      return reject(new Error("tmate-server-port is not a valid integer"))
+    } else if (parsedPort < 1 || 65535 < parsedPort) {
+      return reject(new Error("tmate-server-port does not contain a valid range"))
+    };
+
+    // validate fingerprint
+    const validFingerprintPrefix = "SHA256:"
+    if (!rsaFingerprint.startsWith(validFingerprintPrefix)) {
+      return reject(new Error("tmate-server-rsa-fingerprint has no prefix SHA256:"))
+    };
+    if (!ed25519Fingerprint.startsWith(validFingerprintPrefix)) {
+      return reject(new Error("tmate-server-ed25519-fingerprint has no prefix SHA256:"))
+    };
+
+    return resolve()
+  });
+}

--- a/src/index.js
+++ b/src/index.js
@@ -88,6 +88,15 @@ export async function run() {
     await execShellCommand(`echo 'set +e' >/tmp/tmate.bashrc`);
     const setDefaultCommand = `set-option -g default-command "bash --rcfile /tmp/tmate.bashrc" \\;`;
 
+    const tmateConfPath = path.join(os.homedir(), ".tmate.conf")
+    if (core.getInput("tmate-server-host") !== "") {
+      core.debug("Configure your tmate server")
+      await execShellCommand(`echo 'set -g tmate-server-host ${core.getInput("tmate-server-host")}' >> ${tmateConfPath}`)
+      await execShellCommand(`echo 'set -g tmate-server-port ${core.getInput("tmate-server-port")}' >> ${tmateConfPath}`)
+      await execShellCommand(`echo 'set -g tmate-server-rsa-fingerprint ${core.getInput("tmate-server-rsa-fingerprint")}' >> ${tmateConfPath}`)
+      await execShellCommand(`echo 'set -g tmate-server-ed25519-fingerprint ${core.getInput("tmate-server-ed25519-fingerprint")}' >> ${tmateConfPath}`)
+    }
+
     core.debug("Creating new session")
     await execShellCommand(`${tmate} ${newSessionExtra} ${setDefaultCommand} new-session -d`);
     await execShellCommand(`${tmate} wait tmate-ready`);

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ import * as github from "@actions/github"
 import * as tc from "@actions/tool-cache"
 import { Octokit } from "@octokit/rest"
 
-import { execShellCommand } from "./helpers"
+import { execShellCommand, getValidatedInput } from "./helpers"
 
 const TMATE_LINUX_VERSION = "2.4.0"
 
@@ -27,8 +27,6 @@ const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms));
 export async function run() {
   const optionalSudoPrefix = core.getInput('sudo') === "true" ? "sudo " : "";
   try {
-    await isValidInputOwnServer(core.getInput("tmate-server-host"), core.getInput("tmate-server-port"), core.getInput("tmate-server-rsa-fingerprint"), core.getInput("tmate-server-ed25519-fingerprint"));
-
     core.debug("Installing dependencies")
     let tmateExecutable = "tmate"
     if (process.platform === "darwin") {
@@ -91,10 +89,10 @@ export async function run() {
     let setDefaultCommand = `set-option -g default-command "bash --rcfile /tmp/tmate.bashrc" \\;`;
 
     if (core.getInput("tmate-server-host") !== "") {
-      setDefaultCommand = `${setDefaultCommand} set-option -g tmate-server-host "${core.getInput("tmate-server-host")}\;"`;
-      setDefaultCommand = `${setDefaultCommand} set-option -g tmate-server-port "${core.getInput("tmate-server-port")}\;"`;
-      setDefaultCommand = `${setDefaultCommand} set-option -g tmate-server-rsa-fingerprint "${core.getInput("tmate-server-rsa-fingerprint")}\;"`;
-      setDefaultCommand = `${setDefaultCommand} set-option -g tmate-server-ed25519-fingerprint "${core.getInput("tmate-server-ed25519-fingerprint")}\;"`;
+      setDefaultCommand = `${setDefaultCommand} set-option -g tmate-server-host "${getValidatedInput("tmate-server-host")}" \\;`;
+      setDefaultCommand = `${setDefaultCommand} set-option -g tmate-server-port "${getValidatedInput("tmate-server-port")}" \\;`;
+      setDefaultCommand = `${setDefaultCommand} set-option -g tmate-server-rsa-fingerprint "${getValidatedInput("tmate-server-rsa-fingerprint")}" \\;`;
+      setDefaultCommand = `${setDefaultCommand} set-option -g tmate-server-ed25519-fingerprint "${getValidatedInput("tmate-server-ed25519-fingerprint")}" \\;`;
     }
 
     core.debug("Creating new session")

--- a/src/index.js
+++ b/src/index.js
@@ -27,6 +27,8 @@ const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms));
 export async function run() {
   const optionalSudoPrefix = core.getInput('sudo') === "true" ? "sudo " : "";
   try {
+    await isValidInputOwnServer(core.getInput("tmate-server-host"), core.getInput("tmate-server-port"), core.getInput("tmate-server-rsa-fingerprint"), core.getInput("tmate-server-ed25519-fingerprint"));
+
     core.debug("Installing dependencies")
     let tmateExecutable = "tmate"
     if (process.platform === "darwin") {

--- a/src/index.js
+++ b/src/index.js
@@ -86,15 +86,13 @@ export async function run() {
 
     // Work around potential `set -e` commands in `~/.profile` (looking at you, `setup-miniconda`!)
     await execShellCommand(`echo 'set +e' >/tmp/tmate.bashrc`);
-    const setDefaultCommand = `set-option -g default-command "bash --rcfile /tmp/tmate.bashrc" \\;`;
+    let setDefaultCommand = `set-option -g default-command "bash --rcfile /tmp/tmate.bashrc" \\;`;
 
-    const tmateConfPath = path.join(os.homedir(), ".tmate.conf")
     if (core.getInput("tmate-server-host") !== "") {
-      core.debug("Configure your tmate server")
-      await execShellCommand(`echo 'set -g tmate-server-host ${core.getInput("tmate-server-host")}' >> ${tmateConfPath}`)
-      await execShellCommand(`echo 'set -g tmate-server-port ${core.getInput("tmate-server-port")}' >> ${tmateConfPath}`)
-      await execShellCommand(`echo 'set -g tmate-server-rsa-fingerprint ${core.getInput("tmate-server-rsa-fingerprint")}' >> ${tmateConfPath}`)
-      await execShellCommand(`echo 'set -g tmate-server-ed25519-fingerprint ${core.getInput("tmate-server-ed25519-fingerprint")}' >> ${tmateConfPath}`)
+      setDefaultCommand = `${setDefaultCommand} set-option -g tmate-server-host "${core.getInput("tmate-server-host")}\;"`;
+      setDefaultCommand = `${setDefaultCommand} set-option -g tmate-server-port "${core.getInput("tmate-server-port")}\;"`;
+      setDefaultCommand = `${setDefaultCommand} set-option -g tmate-server-rsa-fingerprint "${core.getInput("tmate-server-rsa-fingerprint")}\;"`;
+      setDefaultCommand = `${setDefaultCommand} set-option -g tmate-server-ed25519-fingerprint "${core.getInput("tmate-server-ed25519-fingerprint")}\;"`;
     }
 
     core.debug("Creating new session")


### PR DESCRIPTION
Hi, I found this action works very well! Thank you for creating this! 😊

Now, `action-tmate` only supports using `ssh.tmate.io`.
This change adds inputs about using other tmate servers.

I referred "Host your own tmate servers" in https://tmate.io/.