### PR TITLE
alpine linux support

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -10243,6 +10243,7 @@ var external_child_process_ = __nccwpck_require__(3129);
 
 
 
+
 /**
  * @param {string} cmd
  * @returns {Promise<string>}
@@ -10295,9 +10296,14 @@ const getValidatedInput = (key) => {
 /**
  * @return {Promise<string>}
  */
-const getLinuxDistro = () => {
-  const distro = execShellCommand("cat /etc/os-release | grep ^ID=").then(output => output.substring(3)/* trim 'ID=' */.trim());
-  return distro;
+const getLinuxDistro = async () => {
+  try {
+    const osRelease = await external_fs_default().promises.readFile("/etc/os-release")
+    const match = osRelease.toString().match(/^ID=(.*)$/m)
+    return match ? match[1] : "(unknown)"
+  } catch (e) {
+    return "(unknown)"
+  }
 }
 
 ;// CONCATENATED MODULE: ./src/index.js

--- a/lib/index.js
+++ b/lib/index.js
@@ -10248,6 +10248,7 @@ var external_child_process_ = __nccwpck_require__(3129);
  * @returns {Promise<string>}
  */
 const execShellCommand = (cmd) => {
+  core.debug(`Executing shell command: [${cmd}]`)
   return new Promise((resolve, reject) => {
     const proc = process.platform !== "win32" ?
       (0,external_child_process_.spawn)(cmd, [], { shell: true }) :
@@ -10290,6 +10291,15 @@ const getValidatedInput = (key) => {
   return value;
 }
 
+
+/**
+ * @return {Promise<string>}
+ */
+const getLinuxDistro = () => {
+  const distro = execShellCommand("cat /etc/os-release | grep ^ID=").then(output => output.substring(3)/* trim 'ID=' */.trim());
+  return distro;
+}
+
 ;// CONCATENATED MODULE: ./src/index.js
 // @ts-check
 
@@ -10328,8 +10338,15 @@ async function run() {
       await execShellCommand('pacman -Sy --noconfirm tmate');
       tmateExecutable = 'CHERE_INVOKING=1 tmate'
     } else {
-      await execShellCommand(optionalSudoPrefix + 'apt-get update');
-      await execShellCommand(optionalSudoPrefix + 'apt-get install -y openssh-client xz-utils');
+      const distro = await getLinuxDistro();
+      core.debug("linux distro: [" + distro + "]");
+      if (distro === "alpine") {
+        // for set -e workaround, we need to install bash because alpine doesn't have it
+        await execShellCommand(optionalSudoPrefix + 'apk add openssh-client xz bash');
+      } else {
+        await execShellCommand(optionalSudoPrefix + 'apt-get update');
+        await execShellCommand(optionalSudoPrefix + 'apt-get install -y openssh-client xz-utils');
+      }
 
       const tmateArch = TMATE_ARCH_MAP[external_os_default().arch()];
       if (!tmateArch) {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -7,6 +7,7 @@ import * as core from "@actions/core"
  * @returns {Promise<string>}
  */
 export const execShellCommand = (cmd) => {
+  core.debug(`Executing shell command: [${cmd}]`)
   return new Promise((resolve, reject) => {
     const proc = process.platform !== "win32" ?
       spawn(cmd, [], { shell: true }) :
@@ -47,4 +48,13 @@ export const getValidatedInput = (key) => {
     throw new Error(`Invalid value for '${key}': '${value}'`);
   }
   return value;
+}
+
+
+/**
+ * @return {Promise<string>}
+ */
+export const getLinuxDistro = () => {
+  const distro = execShellCommand("cat /etc/os-release | grep ^ID=").then(output => output.substring(3)/* trim 'ID=' */.trim());
+  return distro;
 }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,6 +1,7 @@
 // @ts-check
 import { spawn } from 'child_process'
 import * as core from "@actions/core"
+import fs from 'fs'
 
 /**
  * @param {string} cmd
@@ -54,7 +55,12 @@ export const getValidatedInput = (key) => {
 /**
  * @return {Promise<string>}
  */
-export const getLinuxDistro = () => {
-  const distro = execShellCommand("cat /etc/os-release | grep ^ID=").then(output => output.substring(3)/* trim 'ID=' */.trim());
-  return distro;
+export const getLinuxDistro = async () => {
+  try {
+    const osRelease = await fs.promises.readFile("/etc/os-release")
+    const match = osRelease.toString().match(/^ID=(.*)$/m)
+    return match ? match[1] : "(unknown)"
+  } catch (e) {
+    return "(unknown)"
+  }
 }


### PR DESCRIPTION
hi, thank you for creating action-tmate! I really love its DX :+1:

thie PR will add support for `alpine linux`, which does not have `apt-get`. 
I added codes to detect linux distro via `/etc/os-release` and use `apk` if distro seems to be alpine.

this already runs fine on my github action, like https://github.com/suntomi/deplo/runs/4402074337?check_suite_focus=true#step:7:26

regards, 