### PR TITLE
Update runners

### DIFF
--- a/.github/workflows/manual-test.yml
+++ b/.github/workflows/manual-test.yml
@@ -7,9 +7,9 @@ jobs:
       fail-fast: false
       matrix:
         runs-on:
-          - ubuntu-16.04
           - ubuntu-18.04
           - ubuntu-20.04
+          - ubuntu-22.04
           - macos-10.15
           - macos-11.0
           - windows-2019


### PR DESCRIPTION
Small PR to replace the Ubuntu 16.04 runner by Ubuntu 22.04. The 16.04 runner was removed a year ago (https://github.blog/changelog/2021-04-29-github-actions-ubuntu-16-04-lts-virtual-environment-will-be-removed-on-september-20-2021/)

Ubuntu 18.04 is deprecated but not yet removed, so I don't know if you want to keep it (https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/)