### PR TITLE
Avoid exceeding the GitHub REST API rate limit

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -35,3 +35,10 @@ inputs:
     description: 'The ed25519 fingerprint for your tmate server'
     required: false
     default: ''
+  github-token:
+    description: >
+      Personal access token (PAT) used to call into GitHub's REST API.
+      We recommend using a service account with the least permissions necessary.
+      Also when generating a new PAT, select the least scopes necessary.
+      [Learn more about creating and using encrypted secrets](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets)
+    default: ${{ github.token }}

--- a/lib/index.js
+++ b/lib/index.js
@@ -12487,7 +12487,13 @@ const execShellCommand = (cmd) => {
   core.debug(`Executing shell command: [${cmd}]`)
   return new Promise((resolve, reject) => {
     const proc = process.platform !== "win32" ?
-      (0,external_child_process_.spawn)(cmd, [], { shell: true }) :
+      (0,external_child_process_.spawn)(cmd, [], {
+        shell: true,
+        env: {
+          ...process.env,
+          HOMEBREW_GITHUB_API_TOKEN: core.getInput('github-token') || undefined
+        }
+      }) :
       (0,external_child_process_.spawn)("C:\\msys64\\usr\\bin\\bash.exe", ["-lc", cmd], {
         env: {
           ...process.env,
@@ -12626,7 +12632,8 @@ async function run() {
     let newSessionExtra = ""
     if (core.getInput("limit-access-to-actor") === "true") {
       const { actor } = github.context
-      const octokit = new dist_node/* Octokit */.v()
+      const auth = core.getInput('github-token')
+      const octokit = new dist_node/* Octokit */.v({ auth })
 
       const keys = await octokit.users.listPublicKeysForUser({
         username: actor

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -20,7 +20,13 @@ export const execShellCommand = (cmd) => {
   core.debug(`Executing shell command: [${cmd}]`)
   return new Promise((resolve, reject) => {
     const proc = process.platform !== "win32" ?
-      spawn(cmd, [], { shell: true }) :
+      spawn(cmd, [], {
+        shell: true,
+        env: {
+          ...process.env,
+          HOMEBREW_GITHUB_API_TOKEN: core.getInput('github-token') || undefined
+        }
+      }) :
       spawn("C:\\msys64\\usr\\bin\\bash.exe", ["-lc", cmd], {
         env: {
           ...process.env,

--- a/src/index.js
+++ b/src/index.js
@@ -81,7 +81,8 @@ export async function run() {
     let newSessionExtra = ""
     if (core.getInput("limit-access-to-actor") === "true") {
       const { actor } = github.context
-      const octokit = new Octokit()
+      const auth = core.getInput('github-token')
+      const octokit = new Octokit({ auth })
 
       const keys = await octokit.users.listPublicKeysForUser({
         username: actor


### PR DESCRIPTION
There was a recent uptick of probems with symptoms like this:

> Error: API rate limit exceeded for 172.176.196.48. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)

Let's follow that advice and use authenticated REST API requests.