### PR TITLE
Fix action-tmate on Windows

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -12577,7 +12577,7 @@ async function run() {
       if (process.platform === "darwin") {
         await execShellCommand('brew install tmate');
       } else if (process.platform === "win32") {
-        await execShellCommand('pacman -Sy --noconfirm tmate');
+        await execShellCommand('pacman -S --noconfirm tmate');
       } else {
         const optionalSudoPrefix = useSudoPrefix() ? "sudo " : "";
         const distro = await getLinuxDistro();

--- a/src/index.js
+++ b/src/index.js
@@ -32,7 +32,7 @@ export async function run() {
       if (process.platform === "darwin") {
         await execShellCommand('brew install tmate');
       } else if (process.platform === "win32") {
-        await execShellCommand('pacman -Sy --noconfirm tmate');
+        await execShellCommand('pacman -S --noconfirm tmate');
       } else {
         const optionalSudoPrefix = useSudoPrefix() ? "sudo " : "";
         const distro = await getLinuxDistro();

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -39,7 +39,7 @@ describe('Tmate GitHub integration', () => {
     const customConnectionString = "foobar"
     execShellCommand.mockReturnValue(Promise.resolve(customConnectionString))
     await run()
-    expect(execShellCommand).toHaveBeenNthCalledWith(1, "pacman -Sy --noconfirm tmate");
+    expect(execShellCommand).toHaveBeenNthCalledWith(1, "pacman -S --noconfirm tmate");
     expect(core.info).toHaveBeenNthCalledWith(1, `Web shell: ${customConnectionString}`);
     expect(core.info).toHaveBeenNthCalledWith(2, `SSH: ${customConnectionString}`);
     expect(core.info).toHaveBeenNthCalledWith(3, "Exiting debugging session because the continue file was created");
@@ -52,7 +52,7 @@ describe('Tmate GitHub integration', () => {
     const customConnectionString = "foobar"
     execShellCommand.mockReturnValue(Promise.resolve(customConnectionString))
     await run()
-    expect(execShellCommand).not.toHaveBeenNthCalledWith(1, "pacman -Sy --noconfirm tmate");
+    expect(execShellCommand).not.toHaveBeenNthCalledWith(1, "pacman -S --noconfirm tmate");
     expect(core.info).toHaveBeenNthCalledWith(1, `Web shell: ${customConnectionString}`);
     expect(core.info).toHaveBeenNthCalledWith(2, `SSH: ${customConnectionString}`);
     expect(core.info).toHaveBeenNthCalledWith(3, "Exiting debugging session because the continue file was created");


### PR DESCRIPTION
Due to [dependency issues](https://hackernoon.com/heres-what-dependency-hell-looks-like-and-how-to-avoid-it-tldr-libraries-may-be-causing-dependency-u87p33vn), it is currently a bit tricky to install the latest version of the `tmate` package on in MSYS2 on GitHub's hosted build agents.

The symptom of the current (incorrect) method is that we're running into "Error 127" which means that either an executable or a DLL was not found.

To install the latest version of the `tmate` package correctly, we would have to do a full upgrade of all installed MSYS2 packages, which would require us to parse the output of the `pacman -Syu` run to figure out whether system packages were upgraded, in which case a second `pacman -Su` invocation would be required.

Instead, let's go the simpler route and avoid updating the package _index_. And then only install the `tmate` package and its not-yet-installed dependencies. That way, we might not get the latest and greatest `tmate` version, but we always get one that actually works.

This fixes https://github.com/mxschmitt/action-tmate/issues/147