### PR TITLE
Add support for a "detached" mode

### DIFF
--- a/.github/workflows/manual-detached-test.yml
+++ b/.github/workflows/manual-detached-test.yml
@@ -1,0 +1,20 @@
+name: Test detached mode
+on: workflow_dispatch
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./
+        with:
+          limit-access-to-actor: true
+          detached: true
+      - run: |
+          echo "A busy loop"
+          for value in $(seq 10)
+          do
+            echo "Value: $value"
+            echo "value $value" >>counter.txt
+            sleep 1
+          done

--- a/README.md
+++ b/README.md
@@ -74,6 +74,26 @@ jobs:
 
 You can then [manually run a workflow](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow) on the desired branch and set `debug_enabled` to true to get a debug session.
 
+## Detached mode
+
+By default, this Action starts a `tmate` session and waits for the session to be done (typically by way of a user connecting and exiting the shell after debugging). In detached mode, this Action will start the `tmate` session, print the connection details, and continue with the next step(s) of the workflow's job. At the end of the job, the Action will wait for the session to exit.
+
+```yaml
+name: CI
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Setup tmate session
+      uses: mxschmitt/action-tmate@v3
+      with:
+        detached: true
+```
+
+By default, this mode will wait at the end of the job for a user to connect and then to terminate the tmate session. If no user has connected within 10 minutes after the post-job step started, it will terminate the `tmate` session and quit gracefully.
+
 ## Without sudo
 
 By default we run installation commands using sudo on Linux. If you get `sudo: not found` you can use the parameter below to execute the commands directly.

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,8 @@ author: 'Max Schmitt'
 runs:
   using: 'node16'
   main: 'lib/index.js'
+  post: 'lib/index.js'
+  post-if: '!cancelled()'
 inputs:
   sudo:
     description: 'If apt should be executed with sudo or without'
@@ -19,6 +21,10 @@ inputs:
     description: 'Whether to authorize only the public SSH keys of the user triggering the workflow (defaults to true if the GitHub profile of the user has a public SSH key)'
     required: false
     default: 'auto'
+  detached:
+    description: 'In detached mode, the workflow job will continue while the tmate session is active'
+    required: false
+    default: 'false'
   tmate-server-host:
     description: 'The hostname for your tmate server (e.g. ssh.example.org)'
     required: false

--- a/lib/index.js
+++ b/lib/index.js
@@ -12481,9 +12481,10 @@ const useSudoPrefix = () => {
 
 /**
  * @param {string} cmd
+ * @param {{quiet: boolean} | undefined} [options]
  * @returns {Promise<string>}
  */
-const execShellCommand = (cmd) => {
+const execShellCommand = (cmd, options) => {
   core.debug(`Executing shell command: [${cmd}]`)
   return new Promise((resolve, reject) => {
     const proc = process.platform !== "win32" ?
@@ -12504,7 +12505,7 @@ const execShellCommand = (cmd) => {
       })
     let stdout = ""
     proc.stdout.on('data', (data) => {
-      process.stdout.write(data);
+      if (!options || !options.quiet) process.stdout.write(data);
       stdout += data.toString();
     });
 
@@ -12577,6 +12578,53 @@ const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms));
 
 async function run() {
   try {
+    /*  Indicates whether the POST action is running */
+    if (!!core.getState('isPost')) {
+      const message = core.getState('message')
+      const tmate = core.getState('tmate')
+      if (tmate && message) {
+        const shutdown = async () => {
+          core.error('Got signal')
+          await execShellCommand(`${tmate} kill-session`)
+          process.exit(1)
+        }
+        // This is needed to fully support canceling the post-job Action, for details see
+        // https://docs.github.com/en/actions/managing-workflow-runs/canceling-a-workflow#steps-github-takes-to-cancel-a-workflow-run
+        process.on('SIGINT', shutdown)
+        process.on('SIGTERM', shutdown)
+        core.debug("Waiting")
+        const hasAnyoneConnectedYet = (() => {
+          let result = false
+          return async () => {
+            return result ||=
+              !didTmateQuit()
+              && '0' !== await execShellCommand(`${tmate} display -p '#{tmate_num_clients}'`, { quiet: true })
+          }
+        })()
+        for (let seconds = 10 * 60; seconds > 0; ) {
+          console.log(`${
+            await hasAnyoneConnectedYet()
+            ? 'Waiting for session to end'
+            : `Waiting for client to connect (at most ${seconds} more second(s))`
+          }\n${message}`)
+
+          if (continueFileExists()) {
+            core.info("Exiting debugging session because the continue file was created")
+            break
+          }
+
+          if (didTmateQuit()) {
+            core.info("Exiting debugging session 'tmate' quit")
+            break
+          }
+
+          await sleep(5000)
+          if (!await hasAnyoneConnectedYet()) seconds -= 5
+        }
+      }
+      return
+    }
+
     let tmateExecutable = "tmate"
     if (core.getInput("install-dependencies") !== "false") {
       core.debug("Installing dependencies")
@@ -12687,6 +12735,36 @@ async function run() {
     core.debug("Fetching connection strings")
     const tmateSSH = await execShellCommand(`${tmate} display -p '#{tmate_ssh}'`);
     const tmateWeb = await execShellCommand(`${tmate} display -p '#{tmate_web}'`);
+
+    /*
+      * Publish a variable so that when the POST action runs, it can determine
+      * it should run the appropriate logic. This is necessary since we don't
+      * have a separate entry point.
+      *
+      * Inspired by https://github.com/actions/checkout/blob/v3.1.0/src/state-helper.ts#L56-L60
+      */
+    core.saveState('isPost', 'true')
+
+    const detached = core.getInput("detached")
+    if (detached === "true") {
+      core.debug("Entering detached mode")
+
+      let message = ''
+      if (publicSSHKeysWarning) {
+        message += `::warning::${publicSSHKeysWarning}\n`
+      }
+      if (tmateWeb) {
+        message += `::notice::Web shell: ${tmateWeb}\n`
+      }
+      message += `::notice::SSH: ${tmateSSH}\n`
+      if (tmateSSHDashI) {
+        message += `::notice::or: ${tmateSSH.replace(/^ssh/, tmateSSHDashI)}\n`
+      }
+      core.saveState('message', message)
+      core.saveState('tmate', tmate)
+      console.log(message)
+      return
+    }
 
     core.debug("Entering main loop")
     while (true) {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -14,9 +14,10 @@ export const useSudoPrefix = () => {
 
 /**
  * @param {string} cmd
+ * @param {{quiet: boolean} | undefined} [options]
  * @returns {Promise<string>}
  */
-export const execShellCommand = (cmd) => {
+export const execShellCommand = (cmd, options) => {
   core.debug(`Executing shell command: [${cmd}]`)
   return new Promise((resolve, reject) => {
     const proc = process.platform !== "win32" ?
@@ -37,7 +38,7 @@ export const execShellCommand = (cmd) => {
       })
     let stdout = ""
     proc.stdout.on('data', (data) => {
-      process.stdout.write(data);
+      if (!options || !options.quiet) process.stdout.write(data);
       stdout += data.toString();
     });
 


### PR DESCRIPTION
In #131, first, and then in #156, a change was proposed to support the same functionality as CircleCI, where a terminal is open concurrent to the running job's steps. And as I [mentioned in the latter PR](https://github.com/mxschmitt/action-tmate/pull/156#issuecomment-1550984902), I have found that feature quite useful (implementing it "manually", by having two `shell: bash` steps).

Here is a very small PR to propose a much simpler UI but essentially offer the same feature: by setting the input `detached: true`, the `action-tmate` step will start a new, detached `tmate` session, print the information how to connect to that, and then continue with the workflow job's next steps, keeping the `tmate` session running. In the post-job phase, `action-tmate` will then wait for the session to end (or, if nobody connected to the session within 10 minutes of that post-job Action, terminate anyway).

Sadly, this PR results in warnings about the usage of the `save-state` command that would only be solved by upgrading to `@actions/core` 1.10.0. However, in https://github.com/mxschmitt/action-tmate/pull/152 we tried that and the same blockers are still there. So I'll punt on that, for now.