### PR TITLE
feat: bump runtime to node 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ branding:
   icon: terminal
 author: 'Max Schmitt'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'lib/index.js'
   post: 'lib/index.js'
   post-if: '!cancelled()'


### PR DESCRIPTION
## Description and Context:

Node 16 reaches the [end of life soon on 11 Sep 2023](https://nodejs.org/en/blog/announcements/nodejs16-eol). This PR updates the default runtime to node20 (Node 20). I have also bumped the actions/checkout version to v4 for the same.

Related issue:

https://github.com/actions/runner/pull/2732

----

A major version bump might be needed after the PRs merge.