### PR TITLE
Add Alma Linux to act the same as Fedora

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -17476,7 +17476,7 @@ async function run() {
         } else if (distro === "arch") {
           // partial upgrades are not supported so also upgrade everything
           await execShellCommand(optionalSudoPrefix + 'pacman -Syu --noconfirm xz openssh');
-        } else if (distro === "fedora" || distroy === "almalinux") {
+        } else if (distro === "fedora" || distro === "almalinux") {
           await execShellCommand(optionalSudoPrefix + 'dnf install -y xz openssh');
         } else {
           await execShellCommand(optionalSudoPrefix + 'apt-get update');

--- a/lib/index.js
+++ b/lib/index.js
@@ -17476,7 +17476,7 @@ async function run() {
         } else if (distro === "arch") {
           // partial upgrades are not supported so also upgrade everything
           await execShellCommand(optionalSudoPrefix + 'pacman -Syu --noconfirm xz openssh');
-        } else if (distro === "fedora") {
+        } else if (distro === "fedora" || distroy === "almalinux") {
           await execShellCommand(optionalSudoPrefix + 'dnf install -y xz openssh');
         } else {
           await execShellCommand(optionalSudoPrefix + 'apt-get update');


### PR DESCRIPTION
Alma Linux is used widely in the form of manylinux containers to build Python packages.

The TMate action did not work in manylinux containers because it was not added in the distros recognition. Using dnf for package installation, just like fedora, works just fine.

I tested this in one of my projects and the TMate session works in a manylinux_2_28 container.