### PR TITLE
docs: fix Jekyll formatting of another code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,9 @@ jobs:
 ## Only on failure
 By default a failed step will cause all following steps to be skipped. You can specify that the tmate session only starts if a previous step [failed](https://docs.github.com/en/actions/learn-github-actions/expressions#failure).
 
+<!--
+{% raw %}
+-->
 ```yaml
 name: CI
 on: [push]
@@ -144,6 +147,9 @@ jobs:
       if: ${{ failure() }}
       uses: mxschmitt/action-tmate@v3
 ```
+<!--
+{% endraw %}
+-->
 
 ## Use registered public SSH key(s)
 


### PR DESCRIPTION
Similar to change proposed in #79.

Another possibility is to drop `${{ ... }}` and simply use `if: <expr>`, since
> GitHub Actions automatically evaluates the `if` conditional as an expression.
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsif

---

Before (https://mxschmitt.github.io/action-tmate/)
![image](https://github.com/mxschmitt/action-tmate/assets/6376638/a7263bc2-c4ea-4277-a993-7484ad17e076)
After (https://muzimuzhi.github.io/action-tmate/, temp)
![image](https://github.com/mxschmitt/action-tmate/assets/6376638/4b1c6a4d-fc4a-4cf8-a47d-71c449ab1d74)
