### PR TITLE
Don't create /continue on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ jobs:
 
 ## Continue a workflow
 
-If you want to continue a workflow and you are inside a tmate session, just create a empty file with the name `continue` either in the root directory or in the project directory by running `touch continue` or `sudo touch /continue`.
+If you want to continue a workflow and you are inside a tmate session, just create a empty file with the name `continue` either in the root directory or in the project directory by running `touch continue` or `sudo touch /continue` (on Linux).
 
 ## Connection string / URL is not visible
 


### PR DESCRIPTION
`sudo touch /continue` does not work on macOS as the root is a read-only filesystem.