### PR TITLE
fix: typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,8 @@ jobs:
     - uses: actions/checkout@v3
     - name: Setup tmate session
       uses: mxschmitt/action-tmate@v3
-      timeout-minutes: 15
+      with:
+        timeout-minutes: 15
 ```
 
 ## Only on failure


### PR DESCRIPTION
Fixes a small typo in an example. The workflow args are passed in with `with:` which is missing in this example.