### PR TITLE
Feat: Connect Timeout

### DIFF
--- a/.github/workflows/manual-detached-test.yml
+++ b/.github/workflows/manual-detached-test.yml
@@ -10,6 +10,7 @@ jobs:
         with:
           limit-access-to-actor: true
           detached: true
+          connect-timeout: 60
       - run: |
           echo "A busy loop"
           for value in $(seq 10)

--- a/.github/workflows/manual-detached-test.yml
+++ b/.github/workflows/manual-detached-test.yml
@@ -10,7 +10,7 @@ jobs:
         with:
           limit-access-to-actor: true
           detached: true
-          connect-timeout: 60
+          connect-timeout-seconds: 60
       - run: |
           echo "A busy loop"
           for value in $(seq 10)

--- a/action.yml
+++ b/action.yml
@@ -25,7 +25,7 @@ inputs:
     description: 'In detached mode, the workflow job will continue while the tmate session is active'
     required: false
     default: 'false'
-  connect-timeout:
+  connect-timeout-seconds:
     description: 'How long in seconds to wait for a connection to be established'
     required: false
     default: '600'

--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,10 @@ inputs:
     description: 'In detached mode, the workflow job will continue while the tmate session is active'
     required: false
     default: 'false'
+  connect-timeout:
+    description: 'How long in seconds to wait for a connection to be established'
+    required: false
+    default: '600'
   tmate-server-host:
     description: 'The hostname for your tmate server (e.g. ssh.example.org)'
     required: false

--- a/lib/index.js
+++ b/lib/index.js
@@ -17435,7 +17435,13 @@ async function run() {
               && '0' !== await execShellCommand(`${tmate} display -p '#{tmate_num_clients}'`, { quiet: true })
           }
         })()
-        for (let seconds = 10 * 60; seconds > 0; ) {
+
+        let connectTimeoutSeconds = parseInt(core.getInput("connect-timeout"))
+        if (Number.isNaN(connectTimeoutSeconds) || connectTimeoutSeconds <= 0) {
+          connectTimeoutSeconds = 10 * 60
+        }
+
+        for (let seconds = connectTimeoutSeconds; seconds > 0; ) {
           console.log(`${
             await hasAnyoneConnectedYet()
             ? 'Waiting for session to end'

--- a/lib/index.js
+++ b/lib/index.js
@@ -17436,7 +17436,7 @@ async function run() {
           }
         })()
 
-        let connectTimeoutSeconds = parseInt(core.getInput("connect-timeout"))
+        let connectTimeoutSeconds = parseInt(core.getInput("connect-timeout-seconds"))
         if (Number.isNaN(connectTimeoutSeconds) || connectTimeoutSeconds <= 0) {
           connectTimeoutSeconds = 10 * 60
         }

--- a/src/index.js
+++ b/src/index.js
@@ -50,7 +50,7 @@ export async function run() {
           }
         })()
 
-        let connectTimeoutSeconds = parseInt(core.getInput("connect-timeout"))
+        let connectTimeoutSeconds = parseInt(core.getInput("connect-timeout-seconds"))
         if (Number.isNaN(connectTimeoutSeconds) || connectTimeoutSeconds <= 0) {
           connectTimeoutSeconds = 10 * 60
         }

--- a/src/index.js
+++ b/src/index.js
@@ -49,7 +49,13 @@ export async function run() {
               && '0' !== await execShellCommand(`${tmate} display -p '#{tmate_num_clients}'`, { quiet: true })
           }
         })()
-        for (let seconds = 10 * 60; seconds > 0; ) {
+
+        let connectTimeoutSeconds = parseInt(core.getInput("connect-timeout"))
+        if (Number.isNaN(connectTimeoutSeconds) || connectTimeoutSeconds <= 0) {
+          connectTimeoutSeconds = 10 * 60
+        }
+
+        for (let seconds = connectTimeoutSeconds; seconds > 0; ) {
           console.log(`${
             await hasAnyoneConnectedYet()
             ? 'Waiting for session to end'


### PR DESCRIPTION
It would be nice to be able to configure the connection timeout separately from the action's overall timeout length. As far as I know, this is currently not possible (issue #133)

I've added a new optional parameter `connection-timeout` that accepts the number of seconds to wait for a connection at maximum. This value is defaulted to 600, which is what the previous fixed value was.