### PR TITLE
Add action typing

### DIFF
--- a/.github/workflows/check-action-typing.yml
+++ b/.github/workflows/check-action-typing.yml
@@ -1,0 +1,16 @@
+name: Check Action Typing
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  check_action_typing:
+    name: Check Action Typing
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check Action Typing
+        uses: typesafegithub/github-actions-typing@v1

--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@
 
 This GitHub Action offers you a direct way to interact with the host system on which the actual scripts (Actions) will run.
 
+Thanks to the provided [typings](action-types.yml), it is possible to use this action in a type-safe way using
+https://github.com/typesafegithub/github-workflows-kt which allows writing workflow files using a type-safe Kotlin DSL.
+
 ## Features
 
 - Debug your GitHub Actions by using SSH or Web shell

--- a/action-types.yml
+++ b/action-types.yml
@@ -1,0 +1,31 @@
+# See https://github.com/typesafegithub/github-actions-typing/
+inputs:
+  sudo:
+    type: boolean
+
+  install-dependencies:
+    type: boolean
+
+  limit-access-to-actor:
+    type: boolean
+
+  detached:
+    type: boolean
+
+  connect-timeout-seconds:
+    type: integer
+
+  tmate-server-host:
+    type: string
+
+  tmate-server-port:
+    type: integer
+
+  tmate-server-rsa-fingerprint:
+    type: string
+
+  tmate-server-ed25519-fingerprint:
+    type: string
+
+  github-token:
+    type: string


### PR DESCRIPTION
I would like to see your action first-class supported by https://github.com/typesafegithub/github-workflows-kt, a Kotlin DSL to write GitHub Action workflows.

The project came up with ways to reduce operational load when keeping the library's action wrappers in sync with actions' inputs and outputs.
The solutions include onboarding https://github.com/typesafegithub/github-actions-typing.
It is as easy as adding an extra YAML file to your repository root, and (optionally) adding a simple GitHub workflow that validates this new file.
Thanks to this, the code generator in the Kotlin DSL can fetch typing info provided by you instead of them, which has a number of benefits.
It has no negative effects on current action consumers, they continue to use the action via regular GitHub API, as if the file was not there.

In this pull request, I would like to ask you if you are open to introduce such typings in your action and also provide the current state as far as I could determine it.
You would not be the first, there are already other actions using it, like e.g. my https://github.com/Vampire/setup-wsl or also Microsoft's https://github.com/microsoft/setup-msbuild.

Also "regular" users can benefit from this clear and formalized typing definition, seeing exactly what values are valid.
And as the typings are made independent from the Kotlin DSL library, also other DSL or similar consumers could use these typings in the future.

When accepting this PR and in the future maintaining the typing yourself,
please keep in mind that API are generated from these typing information.
So if you for example recognize that a type is wrong and want to change it for example from `string` to `integer`,
this would be a breaking change for such consumers and should therefore be done with a major version bump.
Backwards compatible changes like new enum options, or new inputs or outputs can of course be released in a minor version as usual.

After hopefully merging this PR it would be nice if you could cut a release soon,
so that the shiny new typings can be used right away.
