### PR TITLE
Add a "sub-Action" for the detached mode by default

### DIFF
--- a/.github/workflows/manual-detached-test.yml
+++ b/.github/workflows/manual-detached-test.yml
@@ -8,7 +8,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./detached
         with:
-          limit-access-to-actor: true
           connect-timeout-seconds: 60
       - run: |
           echo "A busy loop"

--- a/.github/workflows/manual-detached-test.yml
+++ b/.github/workflows/manual-detached-test.yml
@@ -6,10 +6,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: ./
+      - uses: ./detached
         with:
           limit-access-to-actor: true
-          detached: true
           connect-timeout-seconds: 60
       - run: |
           echo "A busy loop"

--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ jobs:
 
 By default, this mode will wait at the end of the job for a user to connect and then to terminate the tmate session. If no user has connected within 10 minutes after the post-job step started, it will terminate the `tmate` session and quit gracefully.
 
+As this mode has turned out to be so useful as to having the potential for being the default mode once time travel becomes available, it is also available as `mxschmitt/action-tmate/detached` for convenience.
+
 ## Without sudo
 
 By default we run installation commands using sudo on Linux. If you get `sudo: not found` you can use the parameter below to execute the commands directly.

--- a/detached/action.yml
+++ b/detached/action.yml
@@ -1,0 +1,59 @@
+name: 'Debugging with tmate'
+description: 'Debug your GitHub Actions Environment interactively by using SSH or a Web shell'
+branding:
+  icon: terminal
+author: 'Max Schmitt'
+runs:
+  using: 'node20'
+  main: '../lib/index.js'
+  post: '../lib/index.js'
+  post-if: '!cancelled()'
+inputs:
+  sudo:
+    description: 'If apt should be executed with sudo or without'
+    required: false
+    default: 'auto'
+  install-dependencies:
+    description: 'Whether or not to install dependencies for tmate on linux (openssh-client, xz-utils)'
+    required: false
+    default: 'true'
+  limit-access-to-actor:
+    description: 'Whether to authorize only the public SSH keys of the user triggering the workflow (defaults to true if the GitHub profile of the user has a public SSH key)'
+    required: false
+    default: 'auto'
+  detached:
+    description: 'In detached mode, the workflow job will continue while the tmate session is active'
+    required: false
+    default: 'true'
+  connect-timeout-seconds:
+    description: 'How long in seconds to wait for a connection to be established'
+    required: false
+    default: '600'
+  tmate-server-host:
+    description: 'The hostname for your tmate server (e.g. ssh.example.org)'
+    required: false
+    default: ''
+  tmate-server-port:
+    description: 'The port for your tmate server (e.g. 2222)'
+    required: false
+    default: ''
+  tmate-server-rsa-fingerprint:
+    description: 'The RSA fingerprint for your tmate server'
+    required: false
+    default: ''
+  tmate-server-ed25519-fingerprint:
+    description: 'The ed25519 fingerprint for your tmate server'
+    required: false
+    default: ''
+  msys2-location:
+    description: 'The root of the MSYS2 installation (on Windows runners)'
+    required: false
+    default: 'C:\msys64'
+  github-token:
+    description: >
+      Personal access token (PAT) used to call into GitHub's REST API.
+      We recommend using a service account with the least permissions necessary.
+      Also when generating a new PAT, select the least scopes necessary.
+      [Learn more about creating and using encrypted secrets](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets)
+    default: ${{ github.token }}
+


### PR DESCRIPTION
I find myself _only_ using the detached mode as of the past year or so. Naturally, in hindsight I wish for that mode to be the default, for that reason. It would be far from a good idea to change the default _now_, after many years of users having grown accustomed to the current working of the Action.

But there's an easy way to have what I want anyway: by adding a "sub-Action", i.e. a sub-directory with an `action.yml` file that differs only in the default of the `detached` input parameter. That way, I can now use the following in my workflows and get precisely what I want:

```yml
- uses: mxschmitt/action-tmate/detached@v3
```

I imagine that this will be useful for other users, too, therefore I updated the `README.md` file accordingly.