### PR TITLE
ci(manual-test): stop mentioning the obsolete ubuntu-20.04 pool

### DIFF
--- a/.github/workflows/manual-test.yml
+++ b/.github/workflows/manual-test.yml
@@ -7,8 +7,8 @@ jobs:
       fail-fast: false
       matrix:
         runs-on:
-          - ubuntu-20.04
           - ubuntu-22.04
+          - ubuntu-24.04
           - macos-11.0
           - macos-12.0
           - windows-2019


### PR DESCRIPTION
It has gone to the ~Google~GitHub Graveyard.