### PR TITLE
Add support for the ssh commands in output

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ As this mode has turned out to be so useful as to having the potential for being
 When running in detached mode, the action sets the following outputs that can be used in subsequent steps or jobs:
 
 - `ssh-command`: The SSH command to connect to the tmate session
+- `ssh-address`: The raw SSH address without the "ssh" prefix
 - `web-url`: The web URL to connect to the tmate session (if available)
 
 Example workflow using the SSH command in another job:
@@ -113,6 +114,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       ssh-command: ${{ steps.tmate.outputs.ssh-command }}
+      ssh-address: ${{ steps.tmate.outputs.ssh-address }}
     steps:
     - uses: actions/checkout@v4
     - name: Setup tmate session
@@ -127,8 +129,7 @@ jobs:
     steps:
     - name: Display SSH command
       run: |
-        echo "Connect to the tmate session with:"
-        echo ${{ needs.setup-tmate.outputs.ssh-command }}
+        # Send a Slack message to someone telling them they can ssh to ${{ needs.setup-tmate.outputs.ssh-address }}
 ```
 
 ## Without sudo

--- a/README.md
+++ b/README.md
@@ -96,6 +96,41 @@ By default, this mode will wait at the end of the job for a user to connect and 
 
 As this mode has turned out to be so useful as to having the potential for being the default mode once time travel becomes available, it is also available as `mxschmitt/action-tmate/detached` for convenience.
 
+### Using SSH command output in other jobs
+
+When running in detached mode, the action sets the following outputs that can be used in subsequent steps or jobs:
+
+- `ssh-command`: The SSH command to connect to the tmate session
+- `web-url`: The web URL to connect to the tmate session (if available)
+
+Example workflow using the SSH command in another job:
+
+```yaml
+name: Debug with tmate
+on: [push]
+jobs:
+  setup-tmate:
+    runs-on: ubuntu-latest
+    outputs:
+      ssh-command: ${{ steps.tmate.outputs.ssh-command }}
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup tmate session
+      id: tmate
+      uses: mxschmitt/action-tmate@v3
+      with:
+        detached: true
+        
+  use-ssh-command:
+    needs: setup-tmate
+    runs-on: ubuntu-latest
+    steps:
+    - name: Display SSH command
+      run: |
+        echo "Connect to the tmate session with:"
+        echo ${{ needs.setup-tmate.outputs.ssh-command }}
+```
+
 ## Without sudo
 
 By default we run installation commands using sudo on Linux. If you get `sudo: not found` you can use the parameter below to execute the commands directly.

--- a/action.yml
+++ b/action.yml
@@ -56,3 +56,9 @@ inputs:
       Also when generating a new PAT, select the least scopes necessary.
       [Learn more about creating and using encrypted secrets](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets)
     default: ${{ github.token }}
+
+outputs:
+  ssh-command:
+    description: 'The SSH command to connect to the tmate session (only set when detached mode is enabled)'
+  web-url:
+    description: 'The web URL to connect to the tmate session (only set when detached mode is enabled and web URL is available)'

--- a/action.yml
+++ b/action.yml
@@ -60,5 +60,7 @@ inputs:
 outputs:
   ssh-command:
     description: 'The SSH command to connect to the tmate session (only set when detached mode is enabled)'
+  ssh-address:
+    description: 'The raw SSH address without the "ssh" prefix (only set when detached mode is enabled)'
   web-url:
     description: 'The web URL to connect to the tmate session (only set when detached mode is enabled and web URL is available)'

--- a/detached/action.yml
+++ b/detached/action.yml
@@ -57,3 +57,11 @@ inputs:
       [Learn more about creating and using encrypted secrets](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets)
     default: ${{ github.token }}
 
+outputs:
+  ssh-command:
+    description: 'The SSH command to connect to the tmate session (only set when detached mode is enabled)'
+  ssh-address:
+    description: 'The raw SSH address without the "ssh" prefix (only set when detached mode is enabled)'
+  web-url:
+    description: 'The web URL to connect to the tmate session (only set when detached mode is enabled and web URL is available)'
+

--- a/lib/index.js
+++ b/lib/index.js
@@ -17602,6 +17602,13 @@ async function run() {
       }
       core.saveState('message', message)
       core.saveState('tmate', tmate)
+      
+      // Set the SSH command as an output so other jobs can use it
+      core.setOutput('ssh-command', tmateSSH)
+      if (tmateWeb) {
+        core.setOutput('web-url', tmateWeb)
+      }
+      
       console.log(message)
       return
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -17605,6 +17605,8 @@ async function run() {
       
       // Set the SSH command as an output so other jobs can use it
       core.setOutput('ssh-command', tmateSSH)
+      // Extract and set the raw SSH address (without the "ssh" prefix)
+      core.setOutput('ssh-address', tmateSSH.replace(/^ssh /, ''))
       if (tmateWeb) {
         core.setOutput('web-url', tmateWeb)
       }

--- a/src/index.js
+++ b/src/index.js
@@ -219,6 +219,8 @@ export async function run() {
       
       // Set the SSH command as an output so other jobs can use it
       core.setOutput('ssh-command', tmateSSH)
+      // Extract and set the raw SSH address (without the "ssh" prefix)
+      core.setOutput('ssh-address', tmateSSH.replace(/^ssh /, ''))
       if (tmateWeb) {
         core.setOutput('web-url', tmateWeb)
       }

--- a/src/index.js
+++ b/src/index.js
@@ -216,6 +216,13 @@ export async function run() {
       }
       core.saveState('message', message)
       core.saveState('tmate', tmate)
+      
+      // Set the SSH command as an output so other jobs can use it
+      core.setOutput('ssh-command', tmateSSH)
+      if (tmateWeb) {
+        core.setOutput('web-url', tmateWeb)
+      }
+      
       console.log(message)
       return
     }


### PR DESCRIPTION
In complex corporate setups, it is not uncommon that CI processes are designed to notify engineers at strategic times during lengthy workflows. To integrate `action-tmate` in such a process, it is necessary to have vital information (such as the SSH address) at hand, to be able to, say, send a Slack message to the person who will most likely want to connect to the tmate session. This PR adds support for that, by providing said information via Action outputs.