### PR TITLE
ci: verify that the `action.yml` files are in sync

### DIFF
--- a/.github/workflows/checkin.yml
+++ b/.github/workflows/checkin.yml
@@ -13,6 +13,14 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 20
+      - name: Verify that action.yml files are in sync
+        run: |
+          npm run update-detached-action.yml &&
+          if ! git diff --exit-code \*action.yml
+          then
+            echo '::error::action.yml files are not in sync, maybe run `npm run update-detached-action.yml`?'
+            exit 1
+          fi
       - name: Install dependencies
         run: npm ci
       - name: Run tests

--- a/.github/workflows/checkin.yml
+++ b/.github/workflows/checkin.yml
@@ -32,7 +32,8 @@ jobs:
       - name: Verify that the project is built
         run: |
           if [[ -n $(git status -s) ]]; then
-            echo "ERROR: generated dist/ differs from the current sources"
+            echo "ERROR: generated lib/ differs from the current sources"
+            git status -s
             git diff
             exit 1
           fi

--- a/detached/action.yml
+++ b/detached/action.yml
@@ -64,4 +64,3 @@ outputs:
     description: 'The raw SSH address without the "ssh" prefix (only set when detached mode is enabled)'
   web-url:
     description: 'The web URL to connect to the tmate session (only set when detached mode is enabled and web URL is available)'
-

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "start": "node src/index.js",
     "build": "ncc build src/main.js -o lib",
+    "update-detached-action.yml": "sed '/^runs:$/{N;N;N;s/lib\\//..\\/&/g;};/^  detached:/{N;N;N;s/\\(default: .\\)false/\\1true/g;}' action.yml >detached/action.yml",
     "test": "GITHUB_EVENT_PATH= jest"
   },
   "repository": {


### PR DESCRIPTION
In https://github.com/mxschmitt/action-tmate/pull/218, I added a convenient way to launch this Action in detached mode: `mxschmitt/action-tmate/detached@v3`.

The way this is implemented is a copy/edited version of `action.yml` in the `detached/` subdirectory.

This runs the danger of inadvertent divergences, as happened in https://github.com/mxschmitt/action-tmate/pull/221 (which I caught in time and the contributor gracefully addressed).

Let's add automation not only to update the file easily but also to cause a failure in the PR build with a helpful message suggesting how to fix the problem.