### PR TITLE
Convert the `manual-test` workflow to allow specifying which runner OS to use

### DIFF
--- a/.github/workflows/manual-test.yml
+++ b/.github/workflows/manual-test.yml
@@ -6,16 +6,19 @@ on:
         type: choice
         description: 'The runner pool to run the job on'
         required: true
-        default: 'ubuntu-22.04'
+        default: ubuntu-24.04
         options:
-          - ubuntu-22.04
           - ubuntu-24.04
-          - macos-13
-          - macos-14
+          - ubuntu-22.04
+          - macos-15-large
           - macos-15
-          - windows-2019
-          - windows-2022
+          - macos-14-large
+          - macos-14
+          - macos-13
+          - macos-13-xlarge
           - windows-2025
+          - windows-2022
+          - windows-2019
       container-runs-on:
         type: choice
         description: 'The Docker container to run the job on (this overrides the `runs-on` input)'

--- a/.github/workflows/manual-test.yml
+++ b/.github/workflows/manual-test.yml
@@ -1,12 +1,13 @@
-name: Manual test matrix
-on: workflow_dispatch
-
-jobs:
-  test:
-    strategy:
-      fail-fast: false
-      matrix:
-        runs-on:
+name: Manual test
+on:
+  workflow_dispatch:
+    inputs:
+      runs-on:
+        type: choice
+        description: 'The runner pool to run the job on'
+        required: true
+        default: 'ubuntu-22.04'
+        options:
           - ubuntu-22.04
           - ubuntu-24.04
           - macos-13
@@ -15,31 +16,42 @@ jobs:
           - windows-2019
           - windows-2022
           - windows-2025
-        limit-access-to-actor:
-          - true
-          - false
-    runs-on: ${{ matrix.runs-on }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./
-        with:
-          limit-access-to-actor: ${{ matrix.limit-access-to-actor }}
-  test-container:
-    strategy:
-      fail-fast: false
-      matrix:
-        container-runs-on:
+      container-runs-on:
+        type: choice
+        description: 'The Docker container to run the job on (this overrides the `runs-on` input)'
+        required: false
+        default: '(none)'
+        options:
+          - '(none)'
           - fedora:latest
           - archlinux:latest
           - ubuntu:latest
-        limit-access-to-actor:
-          - true
-          - false
-    runs-on: ubuntu-latest
-    container:
-      image: ${{ matrix.container-runs-on }}
+      limit-access-to-actor:
+        type: choice
+        description: 'Whether to limit access to the actor only'
+        required: true
+        default: 'auto'
+        options:
+          - auto
+          - 'true'
+          - 'false'
+
+jobs:
+  test:
+    if: ${{ inputs.container-runs-on == '(none)' }}
+    runs-on: ${{ inputs.runs-on }}
     steps:
       - uses: actions/checkout@v4
       - uses: ./
         with:
-          limit-access-to-actor: ${{ matrix.limit-access-to-actor }}
+          limit-access-to-actor: ${{ inputs.limit-access-to-actor }}
+  test-container:
+    if: ${{ inputs.container-runs-on != '(none)' }}
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ inputs.container-runs-on }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./
+        with:
+          limit-access-to-actor: ${{ inputs.limit-access-to-actor }}

--- a/.github/workflows/manual-test.yml
+++ b/.github/workflows/manual-test.yml
@@ -45,6 +45,18 @@ jobs:
     if: ${{ inputs.container-runs-on == '(none)' }}
     runs-on: ${{ inputs.runs-on }}
     steps:
+      - uses: msys2/setup-msys2@v2
+        # The public preview of GitHub-hosted Windows/ARM64 runners lacks
+        # a working MSYS2 installation, so we need to set it up ourselves.
+        if: ${{ inputs.runs-on == 'windows-11-arm' }}
+        with:
+          msystem: 'CLANGARM64'
+          # We cannot use `C:\` because `msys2/setup-msys2` erroneously
+          # believes that an MSYS2 exists at `C:\msys64`, but it doesn't,
+          # which is the entire reason why we need to set it up in this
+          # here step... However, by using `C:\.\` we can fool that
+          # overzealous check.
+          location: C:\.\
       - uses: actions/checkout@v4
       - uses: ./
         with:

--- a/.github/workflows/manual-test.yml
+++ b/.github/workflows/manual-test.yml
@@ -19,6 +19,7 @@ on:
           - windows-2025
           - windows-2022
           - windows-2019
+          - windows-11-arm
       container-runs-on:
         type: choice
         description: 'The Docker container to run the job on (this overrides the `runs-on` input)'

--- a/.github/workflows/update-manual-test.js
+++ b/.github/workflows/update-manual-test.js
@@ -35,6 +35,11 @@
     })
     .filter(runsOn => runsOn)
 
+  // The Windows/ARM64 runners are in public preview (and for the time being,
+  // not listed in the `runner-images` README file), so we need to add this
+  // manually.
+  if (!choices.includes('windows-11-arm')) choices.push('windows-11-arm')
+
   // Now edit the `manual-test` workflow definition
   const ymlPath = `${__dirname}/manual-test.yml`
   const yml = fs.readFileSync(ymlPath, 'utf8')

--- a/.github/workflows/update-manual-test.js
+++ b/.github/workflows/update-manual-test.js
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+
+// Update the `runs-on` options of the `manual-test.yml` workflow file with the
+// latest available images from the GitHub Actions runner images README file.
+
+(async () => {
+  const fs = require('fs')
+
+  const readme = await (await fetch("https://github.com/actions/runner-images/raw/HEAD/README.md")).text()
+
+  // This will be the first `ubuntu` one.
+  let defaultOption = ''
+
+  const choices = readme
+    // Get the "Available Images" section
+    .split(/\n## Available Images\n/)[1]
+    .split(/##\s*[^#]/)[0]
+    // Split by lines
+    .split('\n')
+    .map(line => {
+        // The relevant lines are table rows; The first column is the image name,
+        // the second one contains a relatively free-form list of the `runs-on`
+        // options that we are interested in. Those `runs-on` options are
+        // surrounded by backticks.
+        const match = line.match(/^\|\s*([^|]+)\s*\|([^|]*)`([^`|]+)`\s*\|/)
+        if (!match) return false // Skip e.g. the table header and empty lines
+        let runsOn = match[3] // default to the last `runs-on` option
+        const alternatives = match[2]
+          .split(/`([^`]*)`/) // split by backticks
+          .filter((_, i) => (i % 2)) // keep only the text between backticks
+          .sort((a, b) => a.length - b.length) // order by length
+        if (alternatives.length > 0 && alternatives[0].length < runsOn.length) runsOn = alternatives[0]
+        if (!defaultOption && match[3].startsWith('ubuntu-')) defaultOption = runsOn
+        return runsOn
+    })
+    .filter(runsOn => runsOn)
+
+  // Now edit the `manual-test` workflow definition
+  const ymlPath = `${__dirname}/manual-test.yml`
+  const yml = fs.readFileSync(ymlPath, 'utf8')
+
+  // We want to replace the `runs-on` options and the `default` value. This
+  // would be easy if there was a built-in YAML parser and renderer in Node.js,
+  // but there is none. Therefore, we use a regular expression to find certain
+  // "needles" near the beginning of the file: first `workflow_dispatch:`,
+  // after that `runs-on:` and then `default:` and `options:`. Then we replace
+  // the `default` value and the `options` values with the new ones.
+  const [, beforeDefault, beforeOptions, optionsIndent, afterOptions] =
+    yml.match(/^([^]*?workflow_dispatch:[^]*?runs-on:[^]*?default:)(?:.*)([^]*?options:)(\n +- )(?:.*)(?:\3.*)*([^]*)/) || []
+  if (!beforeDefault) throw new Error(`The 'manual-test.yml' file does not match the expected format!`)
+  const newYML =
+    `${beforeDefault} ${defaultOption}${[beforeOptions, ...choices].join(optionsIndent)}${afterOptions}`
+  fs.writeFileSync(ymlPath, newYML)
+})().catch(e => {
+  console.error(e)
+  process.exitCode = 1
+})


### PR DESCRIPTION
As I realized in https://github.com/mxschmitt/action-tmate/pull/224#issuecomment-2846405397, the `manual-test` workflow, which is currently set up as a matrix job that runs one job for every available runner OS (and then a couple more Docker containers), is not very useful as-is. Nobody logs into a dozen tmate sessions concurrently to do anything reasonable.

What is typically needed is a single runner OS, or Docker container.

So let's switch this to a workflow where the user specified via `workflow_dispatch` input what exactly they want to run.

While at it, add a script to update the list of available runner images by scraping the official `runner-images` README. I considered adding a scheduled GitHub workflow to update this on a regular basis, but unfortunately `git push` is not permitted with the regular Actions `GITHUB_TOKEN` when it updates anything inside `.github/workflows/`. So this will have to be done manually.

As a doozy, this PR also adds support for running `manual-test` on the shiny new public preview of the GitHub-hosted Windows/ARM64 runners (where it is a bit tricky to run `action-tmate` because the MSYS2 installation is simply not where it is expected, and even `msys2/setup-msys2` expects it to be there and needs to be ~cajoled~convinced to install it).