### PR TITLE
Ignore 'os-release' IDs with surrounding quotes

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -75,7 +75,7 @@ export const getValidatedInput = (key, re) => {
 export const getLinuxDistro = async () => {
   try {
     const osRelease = await fs.promises.readFile("/etc/os-release")
-    const match = osRelease.toString().match(/^ID=(.*)$/m)
+    const match = osRelease.toString().match(/^ID=(?:\W)?(\w*)(?:\W)?$/m)
     return match ? match[1] : "(unknown)"
   } catch (e) {
     return "(unknown)"


### PR DESCRIPTION
On an ubuntu machine, it shows up like:

ID=ubuntu

But on an almalinux machine (at least on mine), it shows up like:

ID="almalinux"

The additional surrounding quotes are causing it to be unidentified, falling back to ubuntu, and then it tries to "apt-get install" dependencies.