### PR TITLE
Fix regex to match Almalinux correctly

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -17376,7 +17376,7 @@ const getValidatedInput = (key, re) => {
 const getLinuxDistro = async () => {
   try {
     const osRelease = await external_fs_default().promises.readFile("/etc/os-release")
-    const match = osRelease.toString().match(/^ID=(.*)$/m)
+    const match = osRelease.toString().match(/^ID="?(.*?)"?$/m)
     return match ? match[1] : "(unknown)"
   } catch (e) {
     return "(unknown)"

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -75,7 +75,7 @@ export const getValidatedInput = (key, re) => {
 export const getLinuxDistro = async () => {
   try {
     const osRelease = await fs.promises.readFile("/etc/os-release")
-    const match = osRelease.toString().match(/^ID=(.*)$/m)
+    const match = osRelease.toString().match(/^ID="?(.*?)"?$/m)
     return match ? match[1] : "(unknown)"
   } catch (e) {
     return "(unknown)"


### PR DESCRIPTION
In AlmaLinux, the ID in /etc/os-release is quoted

```
$ docker run -it --rm almalinux:9 cat /etc/os-release | grep ^ID= 2>/dev/null
ID="almalinux"
```